### PR TITLE
Fixed crash and removed unneeded closing tag

### DIFF
--- a/components/maincontroller.js
+++ b/components/maincontroller.js
@@ -164,9 +164,11 @@
 
         window.VolumeInfo.Level = (event.data['level'] || 1) * 100;
         window.VolumeInfo.IsMuted = event.data['muted'] || false;
-
-        reportEvent('volumechange', true);
-    }
+        
+        if ($scope.userId != null) {
+            reportEvent('volumechange', true);
+        }
+    };
 
     console.log('Application is ready, starting system');
 

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
         <div class="timeOfDay"><span class="timePrefix"></span> <span class="timeSuffix"></span></div>
     </div>
     <video id="video-player" crossorigin="anonymous" preload="auto"></video>
-    <img id="photo"></img>
+    <img id="photo">
     <div id="backdrop">
         <img class="spinner" src="img/spinner.png" />
         <div class="gradient">


### PR DESCRIPTION
It crashes because it doesn't have a userId during initialization where this event is also triggered.