### PR TITLE
Get cast device volume/mute on init and send to client on connect

### DIFF
--- a/components/maincontroller.js
+++ b/components/maincontroller.js
@@ -275,6 +275,7 @@
             if (!isPlaying()) {
                 embyActions.displayUserInfo($scope, data.serverAddress, data.accessToken, data.userId);
             }
+            // when a client connects send back the initial device state (volume etc) via a playbackstop message
             embyActions.reportPlaybackProgress($scope, getReportingParams($scope), true, "playbackstop");
         }
         else if (data.command == 'SetVolume') {

--- a/components/maincontroller.js
+++ b/components/maincontroller.js
@@ -10,6 +10,8 @@
 
         resetPlaybackScope($scope);
         clearMediaElement();
+		window.VolumeInfo.Level = cast.receiver.media.Volume.level * 100;
+		window.VolumeInfo.IsMuted = cast.receiver.media.Volume.muted;
     };
 
     init();
@@ -273,6 +275,7 @@
             if (!isPlaying()) {
                 embyActions.displayUserInfo($scope, data.serverAddress, data.accessToken, data.userId);
             }
+			embyActions.reportPlaybackProgress($scope, getReportingParams($scope), true, "playbackstop");
         }
         else if (data.command == 'SetVolume') {
 

--- a/components/maincontroller.js
+++ b/components/maincontroller.js
@@ -10,8 +10,8 @@
 
         resetPlaybackScope($scope);
         clearMediaElement();
-		window.VolumeInfo.Level = cast.receiver.media.Volume.level * 100;
-		window.VolumeInfo.IsMuted = cast.receiver.media.Volume.muted;
+        window.VolumeInfo.Level = cast.receiver.media.Volume.level * 100;
+        window.VolumeInfo.IsMuted = cast.receiver.media.Volume.muted;
     };
 
     init();
@@ -275,7 +275,7 @@
             if (!isPlaying()) {
                 embyActions.displayUserInfo($scope, data.serverAddress, data.accessToken, data.userId);
             }
-			embyActions.reportPlaybackProgress($scope, getReportingParams($scope), true, "playbackstop");
+            embyActions.reportPlaybackProgress($scope, getReportingParams($scope), true, "playbackstop");
         }
         else if (data.command == 'SetVolume') {
 


### PR DESCRIPTION
this results in the remote control panel in the web(android) client showing the chromecast device volume when connecting to a cast device. The device state (containing the volume/mute among other things) is sent via a "playbackstop" message which normally resets the player state. I also submittet a pr https://github.com/jellyfin/jellyfin-web/pull/222 to jellyfin-web that will fix this and not reset the volume part of the player state.