### PR TITLE
Remove web dependency (mostly)

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ function initRequire(customPaths) {
 
     var paths = {
         browserdeviceprofile: embyWebComponentsBowerPath + "/browserdeviceprofile",
+        codecsupporthelper: "./components/codecsupporthelper",
         castdevices: "./components/castDevices",
         browser: embyWebComponentsBowerPath + "/browser",
         jellyfinactions: 'components/jellyfinactions',

--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ function initRequire(customPaths) {
     var embyWebComponentsBowerPath = bowerPath + '/emby-webcomponents';
 
     var paths = {
-        browserdeviceprofile: embyWebComponentsBowerPath + "/browserdeviceprofile",
+        browserdeviceprofile:  "./components/deviceprofilebuilder",
         codecsupporthelper: "./components/codecsupporthelper",
         castdevices: "./components/castDevices",
         browser: embyWebComponentsBowerPath + "/browser",

--- a/app.js
+++ b/app.js
@@ -33,7 +33,6 @@ function initRequire(customPaths) {
     var embyWebComponentsBowerPath = bowerPath + '/emby-webcomponents';
 
     var paths = {
-        datetime: embyWebComponentsBowerPath + "/datetime",
         browserdeviceprofile: embyWebComponentsBowerPath + "/browserdeviceprofile",
         browser: embyWebComponentsBowerPath + "/browser",
         jellyfinactions: 'components/jellyfinactions',
@@ -88,8 +87,7 @@ function startApp() {
     // Just until we're able to deprecate this
     window.$scope = {};
 
-    require(['fetchhelper', 'maincontroller', 'datetime', 'helpers'], function (fetchhelper, maincontroller, datetime) {
-        window.datetime = datetime;
+    require(['fetchhelper', 'maincontroller', 'helpers'], function (fetchhelper, maincontroller) {
         window.fetchhelper = fetchhelper;
     });
 }

--- a/app.js
+++ b/app.js
@@ -34,6 +34,7 @@ function initRequire(customPaths) {
 
     var paths = {
         browserdeviceprofile: embyWebComponentsBowerPath + "/browserdeviceprofile",
+        castdevices: "./components/castDevices",
         browser: embyWebComponentsBowerPath + "/browser",
         jellyfinactions: 'components/jellyfinactions',
         maincontroller: 'components/maincontroller',

--- a/components/castDevices.js
+++ b/components/castDevices.js
@@ -1,0 +1,41 @@
+define([], function () {
+    "use strict";
+    
+    const castContext = cast.framework.CastReceiverContext.getInstance();
+
+    //Device Ids
+    const GEN1n2 = 1;
+    const AUDIO = 2;
+    const GEN3 = 3;
+    const ULTRA = 4;
+    const NESTHUB = 5;
+
+    /**
+     * Get device id of the active Cast device.
+     * Tries to identify the active Cast device by testing different codec supports.
+     * @returns {number} Active Cast device Id.
+     */
+    function getActiveDeviceId() {
+        if (castContext.canDisplayType("video/mp4", "hev1.1.6.L153.B0") &&
+        castContext.canDisplayType("video/webm", "vp9")) {
+            return ULTRA;
+        } else if (castContext.canDisplayType("video/webm", "vp9")) {
+            return NESTHUB;
+        } else if (castContext.canDisplayType("video/mp4", "avc1.64002A")) {
+            return GEN3;
+        } else if (castContext.canDisplayType("video/mp4", "avc1.640029")) {
+            return GEN1n2;
+        } else {
+            return AUDIO;
+        }
+    }
+
+    return {
+        GEN1n2,
+        AUDIO,
+        GEN3,
+        ULTRA,
+        NESTHUB,
+        getActiveDeviceId
+    };
+});

--- a/components/codecsupporthelper.js
+++ b/components/codecsupporthelper.js
@@ -1,0 +1,177 @@
+define(["castdevices"], function (castDevices) {
+    "use strict";
+
+    const castContext = cast.framework.CastReceiverContext.getInstance();
+
+    function hasH265Support() {
+        return castContext.canDisplayType("video/mp4", "hev1.1.6.L150.B0");
+    }
+
+    function hasTextTrackSupport(deviceId) {
+        return deviceId !== castDevices.AUDIO;
+    }
+
+    function hasVP8Support() {
+        return castContext.canDisplayType("video/webm", "vp8");
+    }
+
+    function hasVP9Support() {
+        return castContext.canDisplayType("video/webm", "vp9");
+    }
+
+    /**
+     * Get the max supported media bitrate for the active Cast device.
+     * @returns {number} Max supported bitrate.
+     */
+    function getMaxBitrateSupport() {
+        // FIXME: We should get this dynamically or hardcode this to values
+        // we see fit for each Cast device. More testing is needed.
+        return 120000000;
+    }
+
+    /**
+     * Get the max supported video width the active Cast device supports.
+     * @param {number} deviceId Cast device id.
+     * @returns {number} Max supported width.
+     */
+    function getMaxWidthSupport(deviceId) {
+        switch (deviceId) {
+            case castDevices.ULTRA:
+                return 3840;
+                break;
+            case castDevices.GEN1n2:
+            case castDevices.GEN3:
+                return 1920;
+                break;
+            case castDevices.NESTHUB:
+                return 1280;
+                break;
+        }
+    }
+
+    /**
+     * Get all H.26x profiles supported by the active Cast device.
+     * @param {number} deviceId Cast device id.
+     * @returns {string} All supported H.26x profiles.
+     */
+    function getH26xProfileSupport(deviceId) {
+        // These are supported by all Cast devices, excluding audio only devices.
+        let h26xProfiles = "high|main|baseline|constrained baseline";
+
+        if (deviceId === castDevices.ULTRA) {
+            h264Profiles += "|high 10"
+        }
+
+        return h26xProfiles;
+    }
+
+    /**
+     * Get the highest H.26x level supported by the active Cast device.
+     * @param {number} deviceId Cast device id.
+     * @returns {number} The highest supported H.26x level.
+     */
+    function getH26xLevelSupport(deviceId) {
+        switch (deviceId) {
+            case castDevices.NESTHUB:
+            case castDevices.GEN1n2:
+                return 41;
+            case castDevices.GEN3:
+                return 42;
+            case castDevices.ULTRA:
+                return 52;
+        }
+    }
+
+    /**
+     * Get VPX (VP8, VP9) codecs supported by the active Cast device.
+     * @returns {Array} Supported VPX codecs.
+     */
+    function getSupportedVPXVideoCodecs() {
+        let codecs = [];
+        if (hasVP8Support()) {
+            codecs.push("VP8");
+        }
+
+        if (hasVP9Support()) {
+            codecs.push("VP9");
+        }
+
+        return codecs;
+    }
+
+    /**
+     * Get supported video codecs suitable for use in an MP4 container.
+     * @returns {Array} Supported MP4 video codecs.
+     */
+    function getSupportedMP4VideoCodecs() {
+        var codecs = ["h264"];
+
+        if (hasH265Support()) {
+            codecs.push("h265");
+            codecs.push("hevc");
+        }
+
+        return codecs;
+    }
+
+    /**
+     * Get supported audio codecs suitable for use in an MP4 container.
+     * @returns {Array} Supported MP4 audio codecs.
+     */
+    function getSupportedMP4AudioCodecs() {
+        return ["aac", "mp3"];
+    }
+
+    /**
+     * Get supported video codecs suitable for use with HLS.
+     * @returns {Array} Supported HLS video codecs.
+     */
+    function getSupportedHLSVideoCodecs() {
+        // Currently the server does not support fmp4 which is required
+        // by the HLS spec for streaming H.265 video.
+        return ["h264"];
+    }
+
+    /**
+     * Get supported audio codecs suitable for use with HLS.
+     * @returns {Array} All supported HLS audio codecs.
+     */
+    function getSupportedHLSAudioCodecs() {
+        // HLS basically supports whatever MP4 supports.
+        return getSupportedMP4AudioCodecs();
+    }
+
+    /**
+     * Get supported audio codecs suitable for use in a WebM container.
+     * @returns {Array} All supported WebM audio codecs.
+     */
+    function getSupportedWebMAudioCodecs() {
+        return ["vorbis", "opus"];
+    }
+
+    /**
+     * Get supported audio codecs suitable for use in a WebM container.
+     * @returns {Array} All supported WebM audio codecs.
+     */
+    function getSupportedAudioCodecs() {
+        return ["opus", "mp3", "aac", "flac", "webma", "wav"];
+    }
+
+    return {
+        hasH265Support,
+        hasTextTrackSupport,
+        hasVP8Support,
+        hasVP9Support,
+        getMaxBitrateSupport,
+        getMaxWidthSupport,
+        getH26xProfileSupport,
+        getH26xLevelSupport,
+        getSupportedVPXVideoCodecs,
+        getSupportedMP4VideoCodecs,
+        getSupportedMP4AudioCodecs,
+        getSupportedHLSVideoCodecs,
+        getSupportedHLSAudioCodecs,
+        getSupportedWebMAudioCodecs,
+        getSupportedAudioCodecs
+    }
+});

--- a/components/deviceprofilebuilder.js
+++ b/components/deviceprofilebuilder.js
@@ -1,0 +1,279 @@
+define(["codecsupporthelper", "castdevices"], function (codecSupport, castDevices) {
+    "use strict";
+
+    let profileOptions;
+    let deviceId;
+
+    /**
+     * @param {string} Property What property the condition should test.
+     * @param {string} Condition The condition to test the values for.
+     * @param {(string|number)} Value The value to compare against.
+     * @param {boolean} [IsRequired=false]
+     * @returns {Object} A profile condition created from the parameters.
+     */
+    function createProfileCondition(Property, Condition, Value, IsRequired = false) {
+        return {
+            Condition,
+            Property,
+            Value,
+            IsRequired
+        }
+    }
+
+    /**
+     * @returns {Object} Container profiles.
+     */
+    function getContainerProfiles() {
+        return [];
+    }
+
+    /**
+     * @returns {Object} Response profiles.
+     */
+    function getResponseProfiles() {
+        //This seems related to DLNA, it might not be needed?
+        return [{
+            Type: "Video",
+            Container: "m4v",
+            MimeType: "video/mp4"
+        }];
+    }
+
+    /**
+     * @returns {Object} Direct play profiles.
+     */
+    function getDirectPlayProfiles() {
+        let DirectPlayProfiles = [];
+
+        if (deviceId !== castDevices.AUDIO) {
+            const mp4VideoCodecs = codecSupport.getSupportedMP4VideoCodecs();
+            const mp4AudioCodecs = codecSupport.getSupportedMP4AudioCodecs();
+            const vpxVideoCodecs = codecSupport.getSupportedVPXVideoCodecs();
+            const webmAudioCodecs = codecSupport.getSupportedWebMAudioCodecs();
+
+            for (const codec of vpxVideoCodecs) {
+                DirectPlayProfiles.push({
+                    Container: "webm",
+                    Type: "Video",
+                    AudioCodec: webmAudioCodecs.join(","),
+                    VideoCodec: codec
+                });
+            }
+
+            DirectPlayProfiles.push({
+                Container: "mp4,m4v",
+                Type: "Video",
+                VideoCodec: mp4VideoCodecs.join(","),
+                AudioCodec: mp4AudioCodecs.join(",")
+            });
+        }
+
+        const supportedAudio = codecSupport.getSupportedAudioCodecs();
+
+        for (const audioFormat of supportedAudio) {
+            if (audioFormat === "mp3") {
+                DirectPlayProfiles.push({
+                    Container: audioFormat,
+                    Type: "Audio",
+                    AudioCodec: audioFormat
+                });
+            } else if (audioFormat === "webma") {
+                DirectPlayProfiles.push({
+                    Container: "webma,webm",
+                    Type: "Audio"
+                });
+            } else {
+                DirectPlayProfiles.push({
+                    Container: audioFormat,
+                    Type: "Audio"
+                });
+            }
+
+            // aac also appears in the m4a and m4b container
+            if (audioFormat === "aac") {
+                DirectPlayProfiles.push({
+                    Container: "m4a,m4b",
+                    AudioCodec: audioFormat,
+                    Type: "Audio"
+                });
+            }
+        }
+
+        return DirectPlayProfiles;
+    }
+
+    /**
+     * @returns {Object} Codec profiles.
+     */
+    function getCodecProfiles() {
+        let CodecProfiles = [];
+
+        if (deviceId !== castDevices.AUDIO) {
+            CodecProfiles.push({
+                Type: "VideoAudio",
+                Codec: "aac",
+                Conditions: [
+                    // Not sure what secondary audio means in this context. Multiple audio tracks?
+                    createProfileCondition("IsSecondaryAudio", "Equals", false),
+                    createProfileCondition("AudioChannels", "LessThanEqual", "2")
+                ]
+            });
+
+            const maxWidth = codecSupport.getMaxWidthSupport(deviceId);
+            const h26xLevel = codecSupport.getH26xLevelSupport(deviceId);
+            const h26xProfile = codecSupport.getH26xProfileSupport(deviceId);
+
+            let h26xConditions = {
+                Type: "Video",
+                Codec: "h264",
+                Conditions: [
+                    createProfileCondition("IsAnamorphic", "NotEquals", true),
+                    createProfileCondition("VideoProfile", "EqualsAny", h26xProfile),
+                    createProfileCondition("VideoLevel", "LessThanEqual", h26xLevel),
+                    createProfileCondition("Width", "LessThanEqual", maxWidth, true)
+                ]
+            }
+
+            CodecProfiles.push(h26xConditions);
+
+            CodecProfiles.push({
+                Type: "Video",
+                Conditions: [
+                    createProfileCondition("Width", "LessThanEqual", maxWidth, true)
+                ]
+            })
+
+            CodecProfiles.push({
+                Type: "VideoAudio",
+                Conditions: [
+                    createProfileCondition("IsSecondaryAudio", "Equals", false)
+                ]
+            });
+        }
+
+        return CodecProfiles;
+    }
+
+    /**
+     * @returns {Array} Transcoding profiles.
+     */
+    function getTranscodingProfiles() {
+        let TranscodingProfiles = [];
+
+        let physicalAudioChannels = profileOptions.audioChannels ? 6 : 2;
+
+        if (profileOptions.enableHls !== false) {
+            TranscodingProfiles.push({
+                Container: "ts",
+                Type: "Audio",
+                AudioCodec: "aac",
+                Context: "Streaming",
+                Protocol: "hls",
+                MaxAudioChannels: physicalAudioChannels.toString(),
+                MinSegments: "1",
+                BreakOnNonKeyFrames: false
+            });
+        };
+
+        const supportedAudio = codecSupport.getSupportedAudioCodecs();
+
+        for (const audioFormat of supportedAudio) {
+            TranscodingProfiles.push({
+                Container: audioFormat,
+                Type: "Audio",
+                AudioCodec: audioFormat,
+                Context: "Streaming",
+                Protocol: "http",
+                MaxAudioChannels: physicalAudioChannels.toString()
+            });
+        }
+
+        if (deviceId !== castDevices.AUDIO) {
+            const hlsVideoAudioCodecs = codecSupport.getSupportedHLSAudioCodecs();
+            const hlsVideoCodecs = codecSupport.getSupportedHLSVideoCodecs();
+            if (hlsVideoCodecs.length &&
+                hlsVideoAudioCodecs.length &&
+                profileOptions.enableHls !== false) {
+                TranscodingProfiles.push({
+                    Container: "ts",
+                    Type: "Video",
+                    AudioCodec: hlsVideoAudioCodecs.join(","),
+                    VideoCodec: hlsVideoCodecs.join(","),
+                    Context: "Streaming",
+                    Protocol: "hls",
+                    MaxAudioChannels: physicalAudioChannels.toString(),
+                    MinSegments: "1",
+                    BreakOnNonKeyFrames: false
+                });
+            }
+
+            if (codecSupport.hasVP8Support() || codecSupport.hasVP9Support()) {
+                TranscodingProfiles.push({
+                    Container: "webm",
+                    Type: "Video",
+                    AudioCodec: "vorbis",
+                    VideoCodec: "vpx",
+                    Context: "Streaming",
+                    Protocol: "http",
+                    // If audio transcoding is needed, limit channels to number of physical audio channels
+                    // Trying to transcode to 5 channels when there are only 2 speakers generally does not sound good
+                    MaxAudioChannels: physicalAudioChannels.toString()
+                });
+            }
+        }
+
+        return TranscodingProfiles;
+    }
+
+    /**
+     * @returns {Array} Subtitle profiles.
+     */
+    function getSubtitleProfiles() {
+        //TODO: Add TTML support
+        let subProfiles = [];
+
+        if (codecSupport.hasTextTrackSupport(deviceId)) {
+            subProfiles.push({
+                Format: "vtt",
+                Method: "External"
+            });
+
+            subProfiles.push({
+                Format: "vtt",
+                Method: "Hls"
+            });
+        }
+
+        return subProfiles;
+    }
+
+    /**
+     * Creates a device profile containing supported codecs for the active Cast device.
+     * @param {Object} [options=Object]
+     * @returns {Object} Device profile.
+     */
+    function getDeviceProfile(options = {}) {
+        profileOptions = options;
+        deviceId = castDevices.getActiveDeviceId();
+
+        const bitrateSetting = options.bitrateSetting || codecSupport.getMaxBitrateSupport();
+
+        //MaxStaticBitrate seems to be for offline sync only
+        let profile = {
+            MaxStreamingBitrate: 120000000, //bitrateSetting,
+            MaxStaticBitrate: 0,
+            MusicStreamingTranscodingBitrate: Math.min(bitrateSetting, 192000)
+        };
+
+        profile.DirectPlayProfiles = getDirectPlayProfiles();
+        profile.TranscodingProfiles = getTranscodingProfiles();
+        profile.ContainerProfile = getContainerProfiles();
+        profile.CodecProfiles = getCodecProfiles();
+        profile.SubtitleProfiles = getSubtitleProfiles();
+        profile.ResponseProfiles = getResponseProfiles();
+
+        return profile;
+    }
+
+    return getDeviceProfile;
+});

--- a/components/jellyfinactions.js
+++ b/components/jellyfinactions.js
@@ -1,4 +1,4 @@
-﻿define(['datetime', 'fetchhelper'], function (datetime, fetchhelper) {
+﻿define(['fetchhelper'], function (fetchhelper) {
 
     var factory = {};
 
@@ -241,7 +241,7 @@
         setOverview(item.Overview || '');
         setGenres(item.Genres.join(' / '));
         setDisplayName(getDisplayName(item));
-        document.getElementById('miscInfo').innerHTML = getMiscInfoHtml(item, datetime) || '';
+        document.getElementById('miscInfo').innerHTML = getMiscInfoHtml(item) || '';
         document.getElementById('detailRating').innerHTML = getRatingHtml(item);
 
         var playedIndicator = document.getElementById('playedIndicator');

--- a/components/maincontroller.js
+++ b/components/maincontroller.js
@@ -1,4 +1,4 @@
-﻿define(['datetime', 'jellyfinactions', 'browserdeviceprofile', '//www.gstatic.com/cast/sdk/libs/caf_receiver/v3/cast_receiver_framework.js'], function (datetime, jellyfinActions, deviceProfileBuilder) {
+﻿define(['jellyfinactions', 'browserdeviceprofile', '//www.gstatic.com/cast/sdk/libs/caf_receiver/v3/cast_receiver_framework.js'], function (jellyfinActions, deviceProfileBuilder) {
     window.castReceiverContext = cast.framework.CastReceiverContext.getInstance();
     window.mediaManager = window.castReceiverContext.getPlayerManager();
     window.mediaManager.addEventListener(cast.framework.events.category.CORE,
@@ -896,7 +896,7 @@
             playSessionId: playSessionId
         }
 
-        mediaInfo.metadata = getMetadata(item, datetime);
+        mediaInfo.metadata = getMetadata(item);
 
         mediaInfo.streamType = cast.framework.messages.StreamType.BUFFERED;
         mediaInfo.tracks = streamInfo.tracks;

--- a/components/maincontroller.js
+++ b/components/maincontroller.js
@@ -1,4 +1,4 @@
-﻿define(['jellyfinactions', 'browserdeviceprofile', '//www.gstatic.com/cast/sdk/libs/caf_receiver/v3/cast_receiver_framework.js'], function (jellyfinActions, deviceProfileBuilder) {
+﻿define(['jellyfinactions', 'browserdeviceprofile'], function (jellyfinActions, deviceProfileBuilder) {
     window.castReceiverContext = cast.framework.CastReceiverContext.getInstance();
     window.mediaManager = window.castReceiverContext.getPlayerManager();
     window.mediaManager.addEventListener(cast.framework.events.category.CORE,

--- a/components/maincontroller.js
+++ b/components/maincontroller.js
@@ -617,63 +617,15 @@
 
     function getDeviceProfile(maxBitrate) {
 
-        var transcodingAudioChannels = document.createElement('video').canPlayType('audio/mp4; codecs="ac-3"').replace(/no/, '') ?
+        let transcodingAudioChannels = document.createElement('video').canPlayType('audio/mp4; codecs="ac-3"').replace(/no/, '') ?
             6 :
             2;
 
-        var profile = deviceProfileBuilder({
+        return deviceProfileBuilder({
             supportsCustomSeeking: true,
             audioChannels: transcodingAudioChannels
         });
 
-        profile.MaxStreamingBitrate = maxBitrate;
-        profile.MaxStaticBitrate = maxBitrate;
-        profile.MusicStreamingTranscodingBitrate = 192000;
-
-        // This needs to be forced
-        profile.DirectPlayProfiles.push({
-            Container: "flac",
-            Type: 'Audio'
-        });
-
-        profile.SubtitleProfiles = [];
-        profile.SubtitleProfiles.push(
-            {
-                Format: 'vtt',
-                Method: 'External'
-            },
-            {
-                Format: 'vtt',
-                Method: 'Hls'
-            }
-        );
-
-        // Temporary solution until we can make a custom browserdeviceprofile
-        // webm support is currently mistaken for mkv support
-        profile.DirectPlayProfiles = profile.DirectPlayProfiles.filter(item => item.Container !== "mkv");
-
-        profile.TranscodingProfiles = profile.TranscodingProfiles.filter(item => item.Container !== "mkv");
-
-        // TODO: Another temporary solution until we can make a custom browserdeviceprofile
-        // 1st and 2nd gen only support h264 4.1 but browserdeviceprofile is reporting 4.2
-        let context = cast.framework.CastReceiverContext.getInstance();
-        if (context.canDisplayType('video/mp4;codecs=avc1.64002A')) {
-            return profile;
-        }
-        
-        for (prof of profile.CodecProfiles) {
-            if (prof.Codec && prof.Codec.indexOf("h264") == -1) {
-                continue;
-            }
-
-            for (condition of prof.Conditions) {
-                if (condition.Property == "VideoLevel" && condition.Value > 41) {
-                    condition.Value = 41;
-                }
-            }
-        }
-
-        return profile;
     }
 
     function playItemInternal(item, options) {

--- a/helpers.js
+++ b/helpers.js
@@ -993,3 +993,40 @@ function extend(target, source) {
 function parseISO8601Date(s, toLocal) {
     return new Date(s);
 }
+
+function getDisplayRunningTime(ticks) {
+    var ticksPerHour = 36000000000;
+    var ticksPerMinute = 600000000;
+    var ticksPerSecond = 10000000;
+
+    var parts = [];
+
+    var hours = ticks / ticksPerHour;
+    hours = Math.floor(hours);
+
+    if (hours) {
+        parts.push(hours);
+    }
+
+    ticks -= (hours * ticksPerHour);
+
+    var minutes = ticks / ticksPerMinute;
+    minutes = Math.floor(minutes);
+
+    ticks -= (minutes * ticksPerMinute);
+
+    if (minutes < 10 && hours) {
+        minutes = '0' + minutes;
+    }
+    parts.push(minutes);
+
+    var seconds = ticks / ticksPerSecond;
+    seconds = Math.floor(seconds);
+
+    if (seconds < 10) {
+        seconds = '0' + seconds;
+    }
+    parts.push(seconds);
+
+    return parts.join(':');
+}

--- a/helpers.js
+++ b/helpers.js
@@ -223,7 +223,7 @@ function resetPlaybackScope($scope) {
     setDetailImage('');
 }
 
-function getMetadata(item, datetime) {
+function getMetadata(item) {
     var metadata;
     var posterUrl = '';
 
@@ -245,7 +245,7 @@ function getMetadata(item, datetime) {
         metadata.seriesTitle = item.SeriesName;
 
         if (item.PremiereDate) {
-            metadata.originalAirdate = datetime.parseISO8601Date(item.PremiereDate).toISOString();
+            metadata.originalAirdate = parseISO8601Date(item.PremiereDate).toISOString();
         }
 
         if (item.IndexNumber != null) {
@@ -262,7 +262,7 @@ function getMetadata(item, datetime) {
         metadata = new cast.framework.messages.PhotoMediaMetadata();
 
         if (item.PremiereDate) {
-            metadata.creationDateTime = datetime.parseISO8601Date(item.PremiereDate).toISOString();
+            metadata.creationDateTime = parseISO8601Date(item.PremiereDate).toISOString();
         }
         // TODO more metadata?
     }
@@ -276,7 +276,7 @@ function getMetadata(item, datetime) {
         metadata.albumName = item.Album;
         
         if (item.PremiereDate) {
-            metadata.releaseDate = datetime.parseISO8601Date(item.PremiereDate).toISOString();
+            metadata.releaseDate = parseISO8601Date(item.PremiereDate).toISOString();
         }
 
         if (item.IndexNumber != null) {
@@ -300,7 +300,7 @@ function getMetadata(item, datetime) {
 
         metadata = new cast.framework.messages.MovieMediaMetadata();
         if (item.PremiereDate) {
-            metadata.releaseDate = datetime.parseISO8601Date(item.PremiereDate).toISOString();
+            metadata.releaseDate = parseISO8601Date(item.PremiereDate).toISOString();
         }
     }
 
@@ -308,7 +308,7 @@ function getMetadata(item, datetime) {
         metadata = new cast.framework.messages.GenericMediaMetadata();
 
         if (item.PremiereDate) {
-            metadata.releaseDate = datetime.parseISO8601Date(item.PremiereDate).toISOString();
+            metadata.releaseDate = parseISO8601Date(item.PremiereDate).toISOString();
         }
         if (item.Studios && item.Studios.length) {
             metadata.Studio = item.Studios[0];
@@ -818,7 +818,7 @@ function translateRequestedItems(serverAddress, accessToken, userId, items, smar
     return Promise.resolve({ Items: items });
 }
 
-function getMiscInfoHtml(item, datetime) {
+function getMiscInfoHtml(item) {
 
     var miscInfo = [];
     var text, date;
@@ -828,7 +828,7 @@ function getMiscInfoHtml(item, datetime) {
         if (item.PremiereDate) {
 
             try {
-                date = datetime.parseISO8601Date(item.PremiereDate);
+                date = parseISO8601Date(item.PremiereDate);
 
                 text = date.toLocaleDateString();
                 miscInfo.push(text);
@@ -841,7 +841,7 @@ function getMiscInfoHtml(item, datetime) {
 
     if (item.StartDate) {
         try {
-            date = datetime.parseISO8601Date(item.StartDate);
+            date = parseISO8601Date(item.StartDate);
 
             text = date.toLocaleDateString();
             miscInfo.push(text);
@@ -861,10 +861,10 @@ function getMiscInfoHtml(item, datetime) {
             text = item.ProductionYear;
             if (item.EndDate) {
                 try {
-                    var endYear = datetime.parseISO8601Date(item.EndDate).getFullYear();
+                    var endYear = parseISO8601Date(item.EndDate).getFullYear();
 
                     if (endYear != item.ProductionYear) {
-                        text += "-" + datetime.parseISO8601Date(item.EndDate).getFullYear();
+                        text += "-" + parseISO8601Date(item.EndDate).getFullYear();
                     }
 
                 }
@@ -886,7 +886,7 @@ function getMiscInfoHtml(item, datetime) {
         else if (item.PremiereDate) {
 
             try {
-                text = datetime.parseISO8601Date(item.PremiereDate).getFullYear();
+                text = parseISO8601Date(item.PremiereDate).getFullYear();
                 miscInfo.push(text);
             }
             catch (e) {
@@ -901,7 +901,7 @@ function getMiscInfoHtml(item, datetime) {
 
         if (item.Type == "Audio") {
 
-            miscInfo.push(datetime.getDisplayRunningTime(item.RunTimeTicks));
+            miscInfo.push(getDisplayRunningTime(item.RunTimeTicks));
 
         } else {
             minutes = item.RunTimeTicks / 600000000;
@@ -988,4 +988,8 @@ function extend(target, source) {
         target[i] = source[i];
     }
     return target;
+}
+
+function parseISO8601Date(s, toLocal) {
+    return new Date(s);
 }

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <style>
         @import url('https://fonts.googleapis.com/css?family=Quicksand');
     </style>
+    <script src="//www.gstatic.com/cast/sdk/libs/caf_receiver/v3/cast_receiver_framework.js"></script>
 </head>
 <body>
     <div id="waiting-container-backdrop"></div>


### PR DESCRIPTION
Plan is to remove our dependency to web. Datetime and browserdeviceprofile should be fairly straight forward while fetchhelper (included in jellyfin-apiclient-javascript) will take a lot more work, probably better fit for another PR.

**Done:**
- Datetime
- Browserdeviceprofile