### PR TITLE
Convert deviceprofilebuilder and related files to ES6 modules

### DIFF
--- a/src/components/castDevices.js
+++ b/src/components/castDevices.js
@@ -1,41 +1,31 @@
-define([], function () {
-    "use strict";
-    
-    const castContext = cast.framework.CastReceiverContext.getInstance();
+const castContext = cast.framework.CastReceiverContext.getInstance();
 
-    //Device Ids
-    const GEN1n2 = 1;
-    const AUDIO = 2;
-    const GEN3 = 3;
-    const ULTRA = 4;
-    const NESTHUB = 5;
+// Device Ids
+export const deviceIds = {
+    GEN1n2: 1,
+    AUDIO: 2,
+    GEN3: 3,
+    ULTRA: 4,
+    NESTHUB: 5
+}
 
-    /**
-     * Get device id of the active Cast device.
-     * Tries to identify the active Cast device by testing different codec supports.
-     * @returns {number} Active Cast device Id.
-     */
-    function getActiveDeviceId() {
-        if (castContext.canDisplayType("video/mp4", "hev1.1.6.L153.B0") &&
+
+/**
+ * Get device id of the active Cast device.
+ * Tries to identify the active Cast device by testing support for different codecs.
+ * @returns {number} Active Cast device Id.
+ */
+export function getActiveDeviceId() {
+    if (castContext.canDisplayType("video/mp4", "hev1.1.6.L153.B0") &&
         castContext.canDisplayType("video/webm", "vp9")) {
-            return ULTRA;
-        } else if (castContext.canDisplayType("video/webm", "vp9")) {
-            return NESTHUB;
-        } else if (castContext.canDisplayType("video/mp4", "avc1.64002A")) {
-            return GEN3;
-        } else if (castContext.canDisplayType("video/mp4", "avc1.640029")) {
-            return GEN1n2;
-        } else {
-            return AUDIO;
-        }
+        return deviceIds.ULTRA;
+    } else if (castContext.canDisplayType("video/webm", "vp9")) {
+        return deviceIds.NESTHUB;
+    } else if (castContext.canDisplayType("video/mp4", "avc1.64002A")) {
+        return deviceIds.GEN3;
+    } else if (castContext.canDisplayType("video/mp4", "avc1.640029")) {
+        return deviceIds.GEN1n2;
+    } else {
+        return deviceIds.AUDIO;
     }
-
-    return {
-        GEN1n2,
-        AUDIO,
-        GEN3,
-        ULTRA,
-        NESTHUB,
-        getActiveDeviceId
-    };
-});
+}

--- a/src/components/codecsupporthelper.js
+++ b/src/components/codecsupporthelper.js
@@ -1,177 +1,154 @@
-define(["castdevices"], function (castDevices) {
-    "use strict";
+import { deviceIds } from "./castDevices";
 
-    const castContext = cast.framework.CastReceiverContext.getInstance();
+const castContext = cast.framework.CastReceiverContext.getInstance();
 
-    function hasH265Support() {
-        return castContext.canDisplayType("video/mp4", "hev1.1.6.L150.B0");
+export function hasH265Support() {
+    return castContext.canDisplayType("video/mp4", "hev1.1.6.L150.B0");
+}
+
+export function hasTextTrackSupport(deviceId) {
+    return deviceId !== deviceIds.AUDIO;
+}
+
+export function hasVP8Support() {
+    return castContext.canDisplayType("video/webm", "vp8");
+}
+
+export function hasVP9Support() {
+    return castContext.canDisplayType("video/webm", "vp9");
+}
+
+/**
+ * Get the max supported media bitrate for the active Cast device.
+ * @returns {number} Max supported bitrate.
+ */
+export function getMaxBitrateSupport() {
+    // FIXME: We should get this dynamically or hardcode this to values
+    // we see fit for each Cast device. More testing is needed.
+    return 120000000;
+}
+
+/**
+ * Get the max supported video width the active Cast device supports.
+ * @param {number} deviceId Cast device id.
+ * @returns {number} Max supported width.
+ */
+export function getMaxWidthSupport(deviceId) {
+    switch (deviceId) {
+        case deviceIds.ULTRA:
+            return 3840;
+        case deviceIds.GEN1n2:
+        case deviceIds.GEN3:
+            return 1920;
+        case deviceIds.NESTHUB:
+            return 1280;
+    }
+}
+
+/**
+ * Get all H.26x profiles supported by the active Cast device.
+ * @param {number} deviceId Cast device id.
+ * @returns {string} All supported H.26x profiles.
+ */
+export function getH26xProfileSupport(deviceId) {
+    // These are supported by all Cast devices, excluding audio only devices.
+    let h26xProfiles = "high|main|baseline|constrained baseline";
+
+    if (deviceId === deviceIds.ULTRA) {
+        h264Profiles += "|high 10"
     }
 
-    function hasTextTrackSupport(deviceId) {
-        return deviceId !== castDevices.AUDIO;
+    return h26xProfiles;
+}
+
+/**
+ * Get the highest H.26x level supported by the active Cast device.
+ * @param {number} deviceId Cast device id.
+ * @returns {number} The highest supported H.26x level.
+ */
+export function getH26xLevelSupport(deviceId) {
+    switch (deviceId) {
+        case deviceIds.NESTHUB:
+        case deviceIds.GEN1n2:
+            return 41;
+        case deviceIds.GEN3:
+            return 42;
+        case deviceIds.ULTRA:
+            return 52;
+    }
+}
+
+/**
+ * Get VPX (VP8, VP9) codecs supported by the active Cast device.
+ * @returns {Array} Supported VPX codecs.
+ */
+export function getSupportedVPXVideoCodecs() {
+    let codecs = [];
+    if (hasVP8Support()) {
+        codecs.push("VP8");
     }
 
-    function hasVP8Support() {
-        return castContext.canDisplayType("video/webm", "vp8");
+    if (hasVP9Support()) {
+        codecs.push("VP9");
     }
 
-    function hasVP9Support() {
-        return castContext.canDisplayType("video/webm", "vp9");
+    return codecs;
+}
+
+/**
+ * Get supported video codecs suitable for use in an MP4 container.
+ * @returns {Array} Supported MP4 video codecs.
+ */
+export function getSupportedMP4VideoCodecs() {
+    var codecs = ["h264"];
+
+    if (hasH265Support()) {
+        codecs.push("h265");
+        codecs.push("hevc");
     }
 
-    /**
-     * Get the max supported media bitrate for the active Cast device.
-     * @returns {number} Max supported bitrate.
-     */
-    function getMaxBitrateSupport() {
-        // FIXME: We should get this dynamically or hardcode this to values
-        // we see fit for each Cast device. More testing is needed.
-        return 120000000;
-    }
+    return codecs;
+}
 
-    /**
-     * Get the max supported video width the active Cast device supports.
-     * @param {number} deviceId Cast device id.
-     * @returns {number} Max supported width.
-     */
-    function getMaxWidthSupport(deviceId) {
-        switch (deviceId) {
-            case castDevices.ULTRA:
-                return 3840;
-                break;
-            case castDevices.GEN1n2:
-            case castDevices.GEN3:
-                return 1920;
-                break;
-            case castDevices.NESTHUB:
-                return 1280;
-                break;
-        }
-    }
+/**
+ * Get supported audio codecs suitable for use in an MP4 container.
+ * @returns {Array} Supported MP4 audio codecs.
+ */
+export function getSupportedMP4AudioCodecs() {
+    return ["aac", "mp3"];
+}
 
-    /**
-     * Get all H.26x profiles supported by the active Cast device.
-     * @param {number} deviceId Cast device id.
-     * @returns {string} All supported H.26x profiles.
-     */
-    function getH26xProfileSupport(deviceId) {
-        // These are supported by all Cast devices, excluding audio only devices.
-        let h26xProfiles = "high|main|baseline|constrained baseline";
+/**
+ * Get supported video codecs suitable for use with HLS.
+ * @returns {Array} Supported HLS video codecs.
+ */
+export function getSupportedHLSVideoCodecs() {
+    // Currently the server does not support fmp4 which is required
+    // by the HLS spec for streaming H.265 video.
+    return ["h264"];
+}
 
-        if (deviceId === castDevices.ULTRA) {
-            h264Profiles += "|high 10"
-        }
+/**
+ * Get supported audio codecs suitable for use with HLS.
+ * @returns {Array} All supported HLS audio codecs.
+ */
+export function getSupportedHLSAudioCodecs() {
+    // HLS basically supports whatever MP4 supports.
+    return getSupportedMP4AudioCodecs();
+}
 
-        return h26xProfiles;
-    }
+/**
+ * Get supported audio codecs suitable for use in a WebM container.
+ * @returns {Array} All supported WebM audio codecs.
+ */
+export function getSupportedWebMAudioCodecs() {
+    return ["vorbis", "opus"];
+}
 
-    /**
-     * Get the highest H.26x level supported by the active Cast device.
-     * @param {number} deviceId Cast device id.
-     * @returns {number} The highest supported H.26x level.
-     */
-    function getH26xLevelSupport(deviceId) {
-        switch (deviceId) {
-            case castDevices.NESTHUB:
-            case castDevices.GEN1n2:
-                return 41;
-            case castDevices.GEN3:
-                return 42;
-            case castDevices.ULTRA:
-                return 52;
-        }
-    }
-
-    /**
-     * Get VPX (VP8, VP9) codecs supported by the active Cast device.
-     * @returns {Array} Supported VPX codecs.
-     */
-    function getSupportedVPXVideoCodecs() {
-        let codecs = [];
-        if (hasVP8Support()) {
-            codecs.push("VP8");
-        }
-
-        if (hasVP9Support()) {
-            codecs.push("VP9");
-        }
-
-        return codecs;
-    }
-
-    /**
-     * Get supported video codecs suitable for use in an MP4 container.
-     * @returns {Array} Supported MP4 video codecs.
-     */
-    function getSupportedMP4VideoCodecs() {
-        var codecs = ["h264"];
-
-        if (hasH265Support()) {
-            codecs.push("h265");
-            codecs.push("hevc");
-        }
-
-        return codecs;
-    }
-
-    /**
-     * Get supported audio codecs suitable for use in an MP4 container.
-     * @returns {Array} Supported MP4 audio codecs.
-     */
-    function getSupportedMP4AudioCodecs() {
-        return ["aac", "mp3"];
-    }
-
-    /**
-     * Get supported video codecs suitable for use with HLS.
-     * @returns {Array} Supported HLS video codecs.
-     */
-    function getSupportedHLSVideoCodecs() {
-        // Currently the server does not support fmp4 which is required
-        // by the HLS spec for streaming H.265 video.
-        return ["h264"];
-    }
-
-    /**
-     * Get supported audio codecs suitable for use with HLS.
-     * @returns {Array} All supported HLS audio codecs.
-     */
-    function getSupportedHLSAudioCodecs() {
-        // HLS basically supports whatever MP4 supports.
-        return getSupportedMP4AudioCodecs();
-    }
-
-    /**
-     * Get supported audio codecs suitable for use in a WebM container.
-     * @returns {Array} All supported WebM audio codecs.
-     */
-    function getSupportedWebMAudioCodecs() {
-        return ["vorbis", "opus"];
-    }
-
-    /**
-     * Get supported audio codecs suitable for use in a WebM container.
-     * @returns {Array} All supported WebM audio codecs.
-     */
-    function getSupportedAudioCodecs() {
-        return ["opus", "mp3", "aac", "flac", "webma", "wav"];
-    }
-
-    return {
-        hasH265Support,
-        hasTextTrackSupport,
-        hasVP8Support,
-        hasVP9Support,
-        getMaxBitrateSupport,
-        getMaxWidthSupport,
-        getH26xProfileSupport,
-        getH26xLevelSupport,
-        getSupportedVPXVideoCodecs,
-        getSupportedMP4VideoCodecs,
-        getSupportedMP4AudioCodecs,
-        getSupportedHLSVideoCodecs,
-        getSupportedHLSAudioCodecs,
-        getSupportedWebMAudioCodecs,
-        getSupportedAudioCodecs
-    }
-});
+/**
+ * Get supported audio codecs suitable for use in a WebM container.
+ * @returns {Array} All supported WebM audio codecs.
+ */
+export function getSupportedAudioCodecs() {
+    return ["opus", "mp3", "aac", "flac", "webma", "wav"];
+}

--- a/src/components/deviceprofilebuilder.js
+++ b/src/components/deviceprofilebuilder.js
@@ -1,279 +1,296 @@
-define(["codecsupporthelper", "castdevices"], function (codecSupport, castDevices) {
-    "use strict";
+import {
+    deviceIds,
+    getActiveDeviceId
+} from "./castDevices";
+import {
+    hasTextTrackSupport,
+    hasVP8Support,
+    hasVP9Support,
+    getMaxBitrateSupport,
+    getMaxWidthSupport,
+    getH26xProfileSupport,
+    getH26xLevelSupport,
+    getSupportedVPXVideoCodecs,
+    getSupportedMP4VideoCodecs,
+    getSupportedMP4AudioCodecs,
+    getSupportedHLSVideoCodecs,
+    getSupportedHLSAudioCodecs,
+    getSupportedWebMAudioCodecs,
+    getSupportedAudioCodecs
+} from "./codecsupporthelper";
 
-    let profileOptions;
-    let deviceId;
+let profileOptions;
+let currentDeviceId;
 
-    /**
-     * @param {string} Property What property the condition should test.
-     * @param {string} Condition The condition to test the values for.
-     * @param {(string|number)} Value The value to compare against.
-     * @param {boolean} [IsRequired=false]
-     * @returns {Object} A profile condition created from the parameters.
-     */
-    function createProfileCondition(Property, Condition, Value, IsRequired = false) {
-        return {
-            Condition,
-            Property,
-            Value,
-            IsRequired
-        }
+/**
+ * @param {string} Property What property the condition should test.
+ * @param {string} Condition The condition to test the values for.
+ * @param {(string|number)} Value The value to compare against.
+ * @param {boolean} [IsRequired=false]
+ * @returns {Object} A profile condition created from the parameters.
+ */
+function createProfileCondition(Property, Condition, Value, IsRequired = false) {
+    return {
+        Condition,
+        Property,
+        Value,
+        IsRequired
     }
+}
 
-    /**
-     * @returns {Object} Container profiles.
-     */
-    function getContainerProfiles() {
-        return [];
-    }
+/**
+ * @returns {Object} Container profiles.
+ */
+function getContainerProfiles() {
+    return [];
+}
 
-    /**
-     * @returns {Object} Response profiles.
-     */
-    function getResponseProfiles() {
-        //This seems related to DLNA, it might not be needed?
-        return [{
-            Type: "Video",
-            Container: "m4v",
-            MimeType: "video/mp4"
-        }];
-    }
+/**
+ * @returns {Object} Response profiles.
+ */
+function getResponseProfiles() {
+    // This seems related to DLNA, it might not be needed?
+    return [{
+        Type: "Video",
+        Container: "m4v",
+        MimeType: "video/mp4"
+    }];
+}
 
-    /**
-     * @returns {Object} Direct play profiles.
-     */
-    function getDirectPlayProfiles() {
-        let DirectPlayProfiles = [];
+/**
+ * @returns {Object} Direct play profiles.
+ */
+function getDirectPlayProfiles() {
+    let DirectPlayProfiles = [];
 
-        if (deviceId !== castDevices.AUDIO) {
-            const mp4VideoCodecs = codecSupport.getSupportedMP4VideoCodecs();
-            const mp4AudioCodecs = codecSupport.getSupportedMP4AudioCodecs();
-            const vpxVideoCodecs = codecSupport.getSupportedVPXVideoCodecs();
-            const webmAudioCodecs = codecSupport.getSupportedWebMAudioCodecs();
+    if (currentDeviceId !== deviceIds.AUDIO) {
+        const mp4VideoCodecs = getSupportedMP4VideoCodecs();
+        const mp4AudioCodecs = getSupportedMP4AudioCodecs();
+        const vpxVideoCodecs = getSupportedVPXVideoCodecs();
+        const webmAudioCodecs = getSupportedWebMAudioCodecs();
 
-            for (const codec of vpxVideoCodecs) {
-                DirectPlayProfiles.push({
-                    Container: "webm",
-                    Type: "Video",
-                    AudioCodec: webmAudioCodecs.join(","),
-                    VideoCodec: codec
-                });
-            }
-
+        for (const codec of vpxVideoCodecs) {
             DirectPlayProfiles.push({
-                Container: "mp4,m4v",
+                Container: "webm",
                 Type: "Video",
-                VideoCodec: mp4VideoCodecs.join(","),
-                AudioCodec: mp4AudioCodecs.join(",")
+                AudioCodec: webmAudioCodecs.join(","),
+                VideoCodec: codec
             });
         }
 
-        const supportedAudio = codecSupport.getSupportedAudioCodecs();
-
-        for (const audioFormat of supportedAudio) {
-            if (audioFormat === "mp3") {
-                DirectPlayProfiles.push({
-                    Container: audioFormat,
-                    Type: "Audio",
-                    AudioCodec: audioFormat
-                });
-            } else if (audioFormat === "webma") {
-                DirectPlayProfiles.push({
-                    Container: "webma,webm",
-                    Type: "Audio"
-                });
-            } else {
-                DirectPlayProfiles.push({
-                    Container: audioFormat,
-                    Type: "Audio"
-                });
-            }
-
-            // aac also appears in the m4a and m4b container
-            if (audioFormat === "aac") {
-                DirectPlayProfiles.push({
-                    Container: "m4a,m4b",
-                    AudioCodec: audioFormat,
-                    Type: "Audio"
-                });
-            }
-        }
-
-        return DirectPlayProfiles;
+        DirectPlayProfiles.push({
+            Container: "mp4,m4v",
+            Type: "Video",
+            VideoCodec: mp4VideoCodecs.join(","),
+            AudioCodec: mp4AudioCodecs.join(",")
+        });
     }
 
-    /**
-     * @returns {Object} Codec profiles.
-     */
-    function getCodecProfiles() {
-        let CodecProfiles = [];
+    const supportedAudio = getSupportedAudioCodecs();
 
-        if (deviceId !== castDevices.AUDIO) {
-            CodecProfiles.push({
-                Type: "VideoAudio",
-                Codec: "aac",
-                Conditions: [
-                    // Not sure what secondary audio means in this context. Multiple audio tracks?
-                    createProfileCondition("IsSecondaryAudio", "Equals", false),
-                    createProfileCondition("AudioChannels", "LessThanEqual", "2")
-                ]
+    for (const audioFormat of supportedAudio) {
+        if (audioFormat === "mp3") {
+            DirectPlayProfiles.push({
+                Container: audioFormat,
+                Type: "Audio",
+                AudioCodec: audioFormat
             });
-
-            const maxWidth = codecSupport.getMaxWidthSupport(deviceId);
-            const h26xLevel = codecSupport.getH26xLevelSupport(deviceId);
-            const h26xProfile = codecSupport.getH26xProfileSupport(deviceId);
-
-            let h26xConditions = {
-                Type: "Video",
-                Codec: "h264",
-                Conditions: [
-                    createProfileCondition("IsAnamorphic", "NotEquals", true),
-                    createProfileCondition("VideoProfile", "EqualsAny", h26xProfile),
-                    createProfileCondition("VideoLevel", "LessThanEqual", h26xLevel),
-                    createProfileCondition("Width", "LessThanEqual", maxWidth, true)
-                ]
-            }
-
-            CodecProfiles.push(h26xConditions);
-
-            CodecProfiles.push({
-                Type: "Video",
-                Conditions: [
-                    createProfileCondition("Width", "LessThanEqual", maxWidth, true)
-                ]
-            })
-
-            CodecProfiles.push({
-                Type: "VideoAudio",
-                Conditions: [
-                    createProfileCondition("IsSecondaryAudio", "Equals", false)
-                ]
+        } else if (audioFormat === "webma") {
+            DirectPlayProfiles.push({
+                Container: "webma,webm",
+                Type: "Audio"
+            });
+        } else {
+            DirectPlayProfiles.push({
+                Container: audioFormat,
+                Type: "Audio"
             });
         }
 
-        return CodecProfiles;
+        // aac also appears in the m4a and m4b container
+        if (audioFormat === "aac") {
+            DirectPlayProfiles.push({
+                Container: "m4a,m4b",
+                AudioCodec: audioFormat,
+                Type: "Audio"
+            });
+        }
     }
 
-    /**
-     * @returns {Array} Transcoding profiles.
-     */
-    function getTranscodingProfiles() {
-        let TranscodingProfiles = [];
+    return DirectPlayProfiles;
+}
 
-        let physicalAudioChannels = profileOptions.audioChannels ? 6 : 2;
+/**
+ * @returns {Object} Codec profiles.
+ */
+function getCodecProfiles() {
+    let CodecProfiles = [];
 
-        if (profileOptions.enableHls !== false) {
+    if (currentDeviceId !== deviceIds.AUDIO) {
+        CodecProfiles.push({
+            Type: "VideoAudio",
+            Codec: "aac",
+            Conditions: [
+                // Not sure what secondary audio means in this context. Multiple audio tracks?
+                createProfileCondition("IsSecondaryAudio", "Equals", false),
+                createProfileCondition("AudioChannels", "LessThanEqual", "2")
+            ]
+        });
+
+        const maxWidth = getMaxWidthSupport(currentDeviceId);
+        const h26xLevel = getH26xLevelSupport(currentDeviceId);
+        const h26xProfile = getH26xProfileSupport(currentDeviceId);
+
+        let h26xConditions = {
+            Type: "Video",
+            Codec: "h264",
+            Conditions: [
+                createProfileCondition("IsAnamorphic", "NotEquals", true),
+                createProfileCondition("VideoProfile", "EqualsAny", h26xProfile),
+                createProfileCondition("VideoLevel", "LessThanEqual", h26xLevel),
+                createProfileCondition("Width", "LessThanEqual", maxWidth, true)
+            ]
+        }
+
+        CodecProfiles.push(h26xConditions);
+
+        CodecProfiles.push({
+            Type: "Video",
+            Conditions: [
+                createProfileCondition("Width", "LessThanEqual", maxWidth, true)
+            ]
+        })
+
+        CodecProfiles.push({
+            Type: "VideoAudio",
+            Conditions: [
+                createProfileCondition("IsSecondaryAudio", "Equals", false)
+            ]
+        });
+    }
+
+    return CodecProfiles;
+}
+
+/**
+ * @returns {Array} Transcoding profiles.
+ */
+function getTranscodingProfiles() {
+    let TranscodingProfiles = [];
+
+    let physicalAudioChannels = profileOptions.audioChannels ? 6 : 2;
+
+    if (profileOptions.enableHls !== false) {
+        TranscodingProfiles.push({
+            Container: "ts",
+            Type: "Audio",
+            AudioCodec: "aac",
+            Context: "Streaming",
+            Protocol: "hls",
+            MaxAudioChannels: physicalAudioChannels.toString(),
+            MinSegments: "1",
+            BreakOnNonKeyFrames: false
+        });
+    };
+
+    const supportedAudio = getSupportedAudioCodecs();
+
+    for (const audioFormat of supportedAudio) {
+        TranscodingProfiles.push({
+            Container: audioFormat,
+            Type: "Audio",
+            AudioCodec: audioFormat,
+            Context: "Streaming",
+            Protocol: "http",
+            MaxAudioChannels: physicalAudioChannels.toString()
+        });
+    }
+
+    if (currentDeviceId !== deviceIds.AUDIO) {
+        const hlsVideoAudioCodecs = getSupportedHLSAudioCodecs();
+        const hlsVideoCodecs = getSupportedHLSVideoCodecs();
+        if (hlsVideoCodecs.length &&
+            hlsVideoAudioCodecs.length &&
+            profileOptions.enableHls !== false) {
             TranscodingProfiles.push({
                 Container: "ts",
-                Type: "Audio",
-                AudioCodec: "aac",
+                Type: "Video",
+                AudioCodec: hlsVideoAudioCodecs.join(","),
+                VideoCodec: hlsVideoCodecs.join(","),
                 Context: "Streaming",
                 Protocol: "hls",
                 MaxAudioChannels: physicalAudioChannels.toString(),
                 MinSegments: "1",
                 BreakOnNonKeyFrames: false
             });
-        };
+        }
 
-        const supportedAudio = codecSupport.getSupportedAudioCodecs();
-
-        for (const audioFormat of supportedAudio) {
+        if (hasVP8Support() || hasVP9Support()) {
             TranscodingProfiles.push({
-                Container: audioFormat,
-                Type: "Audio",
-                AudioCodec: audioFormat,
+                Container: "webm",
+                Type: "Video",
+                AudioCodec: "vorbis",
+                VideoCodec: "vpx",
                 Context: "Streaming",
                 Protocol: "http",
+                // If audio transcoding is needed, limit channels to number of physical audio channels
+                // Trying to transcode to 5 channels when there are only 2 speakers generally does not sound good
                 MaxAudioChannels: physicalAudioChannels.toString()
             });
         }
-
-        if (deviceId !== castDevices.AUDIO) {
-            const hlsVideoAudioCodecs = codecSupport.getSupportedHLSAudioCodecs();
-            const hlsVideoCodecs = codecSupport.getSupportedHLSVideoCodecs();
-            if (hlsVideoCodecs.length &&
-                hlsVideoAudioCodecs.length &&
-                profileOptions.enableHls !== false) {
-                TranscodingProfiles.push({
-                    Container: "ts",
-                    Type: "Video",
-                    AudioCodec: hlsVideoAudioCodecs.join(","),
-                    VideoCodec: hlsVideoCodecs.join(","),
-                    Context: "Streaming",
-                    Protocol: "hls",
-                    MaxAudioChannels: physicalAudioChannels.toString(),
-                    MinSegments: "1",
-                    BreakOnNonKeyFrames: false
-                });
-            }
-
-            if (codecSupport.hasVP8Support() || codecSupport.hasVP9Support()) {
-                TranscodingProfiles.push({
-                    Container: "webm",
-                    Type: "Video",
-                    AudioCodec: "vorbis",
-                    VideoCodec: "vpx",
-                    Context: "Streaming",
-                    Protocol: "http",
-                    // If audio transcoding is needed, limit channels to number of physical audio channels
-                    // Trying to transcode to 5 channels when there are only 2 speakers generally does not sound good
-                    MaxAudioChannels: physicalAudioChannels.toString()
-                });
-            }
-        }
-
-        return TranscodingProfiles;
     }
 
-    /**
-     * @returns {Array} Subtitle profiles.
-     */
-    function getSubtitleProfiles() {
-        //TODO: Add TTML support
-        let subProfiles = [];
+    return TranscodingProfiles;
+}
 
-        if (codecSupport.hasTextTrackSupport(deviceId)) {
-            subProfiles.push({
-                Format: "vtt",
-                Method: "External"
-            });
+/**
+ * @returns {Array} Subtitle profiles.
+ */
+function getSubtitleProfiles() {
+    // TODO: Add TTML support
+    let subProfiles = [];
 
-            subProfiles.push({
-                Format: "vtt",
-                Method: "Hls"
-            });
-        }
+    if (hasTextTrackSupport(currentDeviceId)) {
+        subProfiles.push({
+            Format: "vtt",
+            Method: "External"
+        });
 
-        return subProfiles;
+        subProfiles.push({
+            Format: "vtt",
+            Method: "Hls"
+        });
     }
 
-    /**
-     * Creates a device profile containing supported codecs for the active Cast device.
-     * @param {Object} [options=Object]
-     * @returns {Object} Device profile.
-     */
-    function getDeviceProfile(options = {}) {
-        profileOptions = options;
-        deviceId = castDevices.getActiveDeviceId();
+    return subProfiles;
+}
 
-        const bitrateSetting = options.bitrateSetting || codecSupport.getMaxBitrateSupport();
+/**
+ * Creates a device profile containing supported codecs for the active Cast device.
+ * @param {Object} [options=Object]
+ * @returns {Object} Device profile.
+ */
+export function getDeviceProfile(options = {}) {
+    profileOptions = options;
+    currentDeviceId = getActiveDeviceId();
 
-        //MaxStaticBitrate seems to be for offline sync only
-        let profile = {
-            MaxStreamingBitrate: 120000000, //bitrateSetting,
-            MaxStaticBitrate: 0,
-            MusicStreamingTranscodingBitrate: Math.min(bitrateSetting, 192000)
-        };
+    const bitrateSetting = options.bitrateSetting || getMaxBitrateSupport();
 
-        profile.DirectPlayProfiles = getDirectPlayProfiles();
-        profile.TranscodingProfiles = getTranscodingProfiles();
-        profile.ContainerProfile = getContainerProfiles();
-        profile.CodecProfiles = getCodecProfiles();
-        profile.SubtitleProfiles = getSubtitleProfiles();
-        profile.ResponseProfiles = getResponseProfiles();
+    // MaxStaticBitrate seems to be for offline sync only
+    let profile = {
+        MaxStreamingBitrate: bitrateSetting,
+        MaxStaticBitrate: 0,
+        MusicStreamingTranscodingBitrate: Math.min(bitrateSetting, 192000)
+    };
 
-        return profile;
-    }
+    profile.DirectPlayProfiles = getDirectPlayProfiles();
+    profile.TranscodingProfiles = getTranscodingProfiles();
+    profile.ContainerProfile = getContainerProfiles();
+    profile.CodecProfiles = getCodecProfiles();
+    profile.SubtitleProfiles = getSubtitleProfiles();
+    profile.ResponseProfiles = getResponseProfiles();
 
-    return getDeviceProfile;
-});
+    return profile;
+}
+
+export default getDeviceProfile;


### PR DESCRIPTION
Basically only changes all `define`s to `import` and exports all functions. Some variables are updated to reference the right imported functions and objects