### PR TITLE
Convert jellyfinactions and fetchhelper to ES6 module

### DIFF
--- a/src/components/fetchhelper.js
+++ b/src/components/fetchhelper.js
@@ -1,0 +1,54 @@
+define([], function() {
+    "use strict";
+
+    function getFetchPromise(request) {
+        var headers = request.headers || {};
+        "json" === request.dataType && (headers.accept = "application/json");
+        var fetchRequest = {
+                headers: headers,
+                method: request.type,
+                credentials: "same-origin"
+            },
+            contentType = request.contentType;
+        request.data && ("string" == typeof request.data ? fetchRequest.body = request.data : (fetchRequest.body = paramsToString(request.data), contentType = contentType || "application/x-www-form-urlencoded; charset=UTF-8")), contentType && (headers["Content-Type"] = contentType);
+        var url = request.url;
+        if (request.query) {
+            var paramString = paramsToString(request.query);
+            paramString && (url += "?" + paramString)
+        }
+        return request.timeout ? fetchWithTimeout(url, fetchRequest, request.timeout) : fetch(url, fetchRequest)
+    }
+
+    function fetchWithTimeout(url, options, timeoutMs) {
+        return console.log("fetchWithTimeout: timeoutMs: " + timeoutMs + ", url: " + url), new Promise(function(resolve, reject) {
+            var timeout = setTimeout(reject, timeoutMs);
+            options = options || {}, options.credentials = "same-origin", fetch(url, options).then(function(response) {
+                clearTimeout(timeout), console.log("fetchWithTimeout: succeeded connecting to url: " + url), resolve(response)
+            }, function(error) {
+                clearTimeout(timeout), console.log("fetchWithTimeout: timed out connecting to url: " + url), reject()
+            })
+        })
+    }
+
+    function paramsToString(params) {
+        var values = [];
+        for (var key in params) {
+            var value = params[key];
+            null !== value && void 0 !== value && "" !== value && values.push(encodeURIComponent(key) + "=" + encodeURIComponent(value))
+        }
+        return values.join("&")
+    }
+
+    function ajax(request) {
+        if (!request) throw new Error("Request cannot be null");
+        return request.headers = request.headers || {}, console.log("requesting url: " + request.url), getFetchPromise(request).then(function(response) {
+            return console.log("response status: " + response.status + ", url: " + request.url), response.status < 400 ? "json" === request.dataType || "application/json" === request.headers.accept ? response.json() : "text" === request.dataType || 0 === (response.headers.get("Content-Type") || "").toLowerCase().indexOf("text/") ? response.text() : response : Promise.reject(response)
+        }, function(err) {
+            throw console.log("request failed to url: " + request.url), err
+        })
+    }
+    return {
+        getFetchPromise: getFetchPromise,
+        ajax: ajax
+    }
+});

--- a/src/components/fetchhelper.js
+++ b/src/components/fetchhelper.js
@@ -1,54 +1,51 @@
-define([], function() {
-    "use strict";
-
-    function getFetchPromise(request) {
-        var headers = request.headers || {};
-        "json" === request.dataType && (headers.accept = "application/json");
-        var fetchRequest = {
-                headers: headers,
-                method: request.type,
-                credentials: "same-origin"
-            },
-            contentType = request.contentType;
-        request.data && ("string" == typeof request.data ? fetchRequest.body = request.data : (fetchRequest.body = paramsToString(request.data), contentType = contentType || "application/x-www-form-urlencoded; charset=UTF-8")), contentType && (headers["Content-Type"] = contentType);
-        var url = request.url;
-        if (request.query) {
-            var paramString = paramsToString(request.query);
-            paramString && (url += "?" + paramString)
-        }
-        return request.timeout ? fetchWithTimeout(url, fetchRequest, request.timeout) : fetch(url, fetchRequest)
+export function getFetchPromise(request) {
+    var headers = request.headers || {};
+    "json" === request.dataType && (headers.accept = "application/json");
+    var fetchRequest = {
+            headers: headers,
+            method: request.type,
+            credentials: "same-origin"
+        },
+        contentType = request.contentType;
+    request.data && ("string" == typeof request.data ? fetchRequest.body = request.data : (fetchRequest.body = paramsToString(request.data), contentType = contentType || "application/x-www-form-urlencoded; charset=UTF-8")), contentType && (headers["Content-Type"] = contentType);
+    var url = request.url;
+    if (request.query) {
+        var paramString = paramsToString(request.query);
+        paramString && (url += "?" + paramString)
     }
+    return request.timeout ? fetchWithTimeout(url, fetchRequest, request.timeout) : fetch(url, fetchRequest)
+}
 
-    function fetchWithTimeout(url, options, timeoutMs) {
-        return console.log("fetchWithTimeout: timeoutMs: " + timeoutMs + ", url: " + url), new Promise(function(resolve, reject) {
-            var timeout = setTimeout(reject, timeoutMs);
-            options = options || {}, options.credentials = "same-origin", fetch(url, options).then(function(response) {
-                clearTimeout(timeout), console.log("fetchWithTimeout: succeeded connecting to url: " + url), resolve(response)
-            }, function(error) {
-                clearTimeout(timeout), console.log("fetchWithTimeout: timed out connecting to url: " + url), reject()
-            })
+export function fetchWithTimeout(url, options, timeoutMs) {
+    return console.log("fetchWithTimeout: timeoutMs: " + timeoutMs + ", url: " + url), new Promise(function (resolve, reject) {
+        var timeout = setTimeout(reject, timeoutMs);
+        options = options || {}, options.credentials = "same-origin", fetch(url, options).then(function (response) {
+            clearTimeout(timeout), console.log("fetchWithTimeout: succeeded connecting to url: " + url), resolve(response)
+        }, function (error) {
+            clearTimeout(timeout), console.log("fetchWithTimeout: timed out connecting to url: " + url), reject()
         })
-    }
+    })
+}
 
-    function paramsToString(params) {
-        var values = [];
-        for (var key in params) {
-            var value = params[key];
-            null !== value && void 0 !== value && "" !== value && values.push(encodeURIComponent(key) + "=" + encodeURIComponent(value))
-        }
-        return values.join("&")
+export function paramsToString(params) {
+    var values = [];
+    for (var key in params) {
+        var value = params[key];
+        null !== value && void 0 !== value && "" !== value && values.push(encodeURIComponent(key) + "=" + encodeURIComponent(value))
     }
+    return values.join("&")
+}
 
-    function ajax(request) {
-        if (!request) throw new Error("Request cannot be null");
-        return request.headers = request.headers || {}, console.log("requesting url: " + request.url), getFetchPromise(request).then(function(response) {
-            return console.log("response status: " + response.status + ", url: " + request.url), response.status < 400 ? "json" === request.dataType || "application/json" === request.headers.accept ? response.json() : "text" === request.dataType || 0 === (response.headers.get("Content-Type") || "").toLowerCase().indexOf("text/") ? response.text() : response : Promise.reject(response)
-        }, function(err) {
-            throw console.log("request failed to url: " + request.url), err
-        })
-    }
-    return {
-        getFetchPromise: getFetchPromise,
-        ajax: ajax
-    }
-});
+export function ajax(request) {
+    if (!request) throw new Error("Request cannot be null");
+    return request.headers = request.headers || {}, console.log("requesting url: " + request.url), getFetchPromise(request).then(function (response) {
+        return console.log("response status: " + response.status + ", url: " + request.url), response.status < 400 ? "json" === request.dataType || "application/json" === request.headers.accept ? response.json() : "text" === request.dataType || 0 === (response.headers.get("Content-Type") || "").toLowerCase().indexOf("text/") ? response.text() : response : Promise.reject(response)
+    }, function (err) {
+        throw console.log("request failed to url: " + request.url), err
+    })
+}
+
+export default {
+    getFetchPromise,
+    ajax
+}

--- a/src/components/jellyfinactions.js
+++ b/src/components/jellyfinactions.js
@@ -1,509 +1,507 @@
-﻿define(['fetchhelper'], function (fetchhelper) {
+﻿import { ajax } from "./fetchhelper";
 
-    var factory = {};
+var factory = {};
 
-    var pingInterval;
-    var lastTranscoderPing = 0;
+var pingInterval;
+var lastTranscoderPing = 0;
 
-    function restartPingInterval($scope, reportingParams) {
+function restartPingInterval($scope, reportingParams) {
 
-        stopPingInterval();
+    stopPingInterval();
 
-        if (reportingParams.PlayMethod == 'Transcode') {
-            pingInterval = setInterval(function () {
-                factory.pingTranscoder($scope, {
-                    PlaySessionId: reportingParams.PlaySessionId
-                });
-            }, 1000);
-        }
+    if (reportingParams.PlayMethod == 'Transcode') {
+        pingInterval = setInterval(function () {
+            factory.pingTranscoder($scope, {
+                PlaySessionId: reportingParams.PlaySessionId
+            });
+        }, 1000);
+    }
+}
+
+function stopPingInterval() {
+
+    var current = pingInterval;
+
+    if (current) {
+        clearInterval(current);
+        pingInterval = null;
+    }
+}
+
+factory.stopPingInterval = function () {
+    stopPingInterval();
+};
+
+factory.reportPlaybackStart = function ($scope, options) {
+
+    this.stopDynamicContent();
+
+    if (!$scope.userId) {
+        throw new Error("null userId");
     }
 
-    function stopPingInterval() {
-
-        var current = pingInterval;
-
-        if (current) {
-            clearInterval(current);
-            pingInterval = null;
-        }
+    if (!$scope.serverAddress) {
+        throw new Error("null serverAddress");
     }
 
-    factory.stopPingInterval = function () {
-        stopPingInterval();
+    var url = getUrl($scope.serverAddress, "Sessions/Playing");
+
+    broadcastToMessageBus({
+        type: 'playbackstart',
+        data: getSenderReportingData($scope, options)
+    });
+
+    restartPingInterval($scope, options);
+
+    return ajax({
+
+        url: url,
+        headers: getSecurityHeaders($scope.accessToken, $scope.userId),
+        type: 'POST',
+        data: JSON.stringify(options),
+        contentType: 'application/json'
+    });
+};
+
+factory.reportPlaybackProgress = function ($scope, options, reportToServer, broadcastEventName) {
+
+    if (!$scope.userId) {
+        throw new Error("null userId");
+    }
+
+    if (!$scope.serverAddress) {
+        throw new Error("null serverAddress");
+    }
+
+    //console.log(JSON.stringify(getSenderReportingData($scope, options)));
+
+    broadcastToMessageBus({
+        type: broadcastEventName || 'playbackprogress',
+        data: getSenderReportingData($scope, options)
+    });
+
+    if (reportToServer === false) {
+        return Promise.resolve();
+    }
+
+    var url = getUrl($scope.serverAddress, "Sessions/Playing/Progress");
+
+    restartPingInterval($scope, options);
+    lastTranscoderPing = new Date().getTime();
+
+    return ajax({
+
+        url: url,
+        headers: getSecurityHeaders($scope.accessToken, $scope.userId),
+        type: 'POST',
+        data: JSON.stringify(options),
+        contentType: 'application/json'
+    });
+};
+
+factory.reportPlaybackStopped = function ($scope, options) {
+
+    stopPingInterval();
+
+    if (!$scope.userId) {
+        throw new Error("null userId");
+    }
+
+    if (!$scope.serverAddress) {
+        throw new Error("null serverAddress");
+    }
+
+    var url = getUrl($scope.serverAddress, "Sessions/Playing/Stopped");
+
+    broadcastToMessageBus({
+        type: 'playbackstop',
+        data: getSenderReportingData($scope, options)
+    });
+
+    return ajax({
+
+        url: url,
+        headers: getSecurityHeaders($scope.accessToken, $scope.userId),
+        type: 'POST',
+        data: JSON.stringify(options),
+        contentType: 'application/json'
+    });
+};
+
+factory.pingTranscoder = function ($scope, options) {
+
+    if (!$scope.userId) {
+        throw new Error("null userId");
+    }
+
+    if (!$scope.serverAddress) {
+        throw new Error("null serverAddress");
+    }
+
+    var now = new Date().getTime();
+    if ((now - lastTranscoderPing) < 10000) {
+
+        console.log("Skipping ping due to recent progress check-in");
+        return new Promise(function (resolve, reject) {
+            resolve();
+        });
+    }
+
+    var url = getUrl($scope.serverAddress, "Sessions/Playing/Ping");
+    lastTranscoderPing = new Date().getTime();
+
+    return ajax({
+
+        url: url,
+        headers: getSecurityHeaders($scope.accessToken, $scope.userId),
+        type: 'POST',
+        data: JSON.stringify(options),
+        contentType: 'application/json'
+    });
+};
+
+var backdropInterval;
+
+function clearBackropInterval() {
+    if (backdropInterval) {
+        clearInterval(backdropInterval);
+        backdropInterval = null;
+    }
+}
+
+function startBackdropInterval($scope, serverAddress, accessToken, userId) {
+
+    clearBackropInterval();
+
+    setRandomUserBackdrop($scope, serverAddress, accessToken, userId);
+
+    backdropInterval = setInterval(function () {
+        setRandomUserBackdrop($scope, serverAddress, accessToken, userId);
+    }, 30000);
+}
+
+function setRandomUserBackdrop($scope, serverAddress, accessToken, userId) {
+
+    console.log('setRandomUserBackdrop');
+
+    var url = getUrl(serverAddress, "Users/" + userId + "/Items");
+
+    ajax({
+        url: url,
+        headers: getSecurityHeaders(accessToken, userId),
+        dataType: 'json',
+        type: 'GET',
+        query: {
+            SortBy: "Random",
+            IncludeItemTypes: "Movie,Series",
+            ImageTypes: 'Backdrop',
+            Recursive: true,
+
+            // Although we're limiting to what the user has access to,
+            // not everyone will want to see adult backdrops rotating on their TV.
+            MaxOfficialRating: 'PG-13',
+
+            Limit: 1
+        }
+
+    }).then(function (result) {
+        var item = result.Items[0];
+
+        var backdropUrl = '';
+
+        if (item) {
+            backdropUrl = getBackdropUrl(item, serverAddress) || '';
+        }
+
+        setWaitingBackdrop(backdropUrl);
+    });
+}
+
+factory.displayUserInfo = function ($scope, serverAddress, accessToken, userId) {
+
+    startBackdropInterval($scope, serverAddress, accessToken, userId);
+};
+
+factory.stopDynamicContent = function () {
+    clearBackropInterval();
+};
+
+function showItem($scope, serverAddress, accessToken, userId, item) {
+
+    clearBackropInterval();
+
+    console.log('showItem');
+
+    var backdropUrl = getBackdropUrl(item, serverAddress) || '';
+    var detailImageUrl = getPrimaryImageUrl(item, serverAddress) || '';
+
+    setAppStatus('details');
+    setWaitingBackdrop(backdropUrl);
+
+    setLogo(getLogoUrl(item, serverAddress) || '');
+    setOverview(item.Overview || '');
+    setGenres(item.Genres.join(' / '));
+    setDisplayName(getDisplayName(item));
+    document.getElementById('miscInfo').innerHTML = getMiscInfoHtml(item) || '';
+    document.getElementById('detailRating').innerHTML = getRatingHtml(item);
+
+    var playedIndicator = document.getElementById('playedIndicator');
+
+    if (item.UserData.Played) {
+
+        playedIndicator.style.display = 'block';
+        playedIndicator.innerHTML = '<span class="glyphicon glyphicon-ok"></span>';
+    } else if (item.UserData.UnplayedItemCount) {
+
+        playedIndicator.style.display = 'block';
+        playedIndicator.innerHTML = item.UserData.UnplayedItemCount;
+    } else {
+        playedIndicator.style.display = 'none';
+    }
+
+    if (item.UserData.PlayedPercentage && item.UserData.PlayedPercentage < 100 && !item.IsFolder) {
+        setHasPlayedPercentage(false);
+        setPlayedPercentage(item.UserData.PlayedPercentage);
+
+        detailImageUrl += "&PercentPlayed=" + parseInt(item.UserData.PlayedPercentage);
+
+    } else {
+        setHasPlayedPercentage(false);
+        setPlayedPercentage(0);
+    }
+
+    setDetailImage(detailImageUrl);
+}
+
+factory.displayItem = function ($scope, serverAddress, accessToken, userId, itemId) {
+
+    console.log('Displaying item: ' + itemId);
+
+    var url = getUrl(serverAddress, "Users/" + userId + "/Items/" + itemId);
+
+    ajax({
+        url: url,
+        headers: getSecurityHeaders(accessToken, userId),
+        dataType: 'json',
+        type: 'GET'
+
+    }).then(function (item) {
+
+        showItem($scope, serverAddress, accessToken, userId, item);
+    });
+};
+
+factory.getSubtitle = function ($scope, subtitleStreamUrl) {
+
+    return ajax({
+
+        url: subtitleStreamUrl,
+        headers: getSecurityHeaders($scope.accessToken, $scope.userId),
+        type: 'GET',
+        dataType: 'json'
+    });
+};
+
+factory.load = function ($scope, customData, serverItem) {
+
+    resetPlaybackScope($scope);
+
+    extend($scope, customData);
+
+    var data = serverItem;
+
+    $scope.item = data;
+
+    setAppStatus('backdrop');
+    $scope.mediaType = data.MediaType;
+};
+
+factory.play = function ($scope, event) {
+    if ($scope.status == 'backdrop' || $scope.status == 'playing-with-controls' || $scope.status == 'playing' || $scope.status == 'audio') {
+        setTimeout(function () {
+
+            var startTime = new Date();
+            window.mediaManager.play();
+
+            setAppStatus('playing-with-controls');
+            if ($scope.mediaType == "Audio") {
+                setAppStatus('audio');
+            }
+        }, 20);
+    }
+};
+
+factory.stop = function ($scope) {
+
+    setTimeout(function () {
+        setAppStatus('waiting');
+    }, 20);
+};
+
+factory.getPlaybackInfo = function (item, maxBitrate, deviceProfile, startPosition, mediaSourceId, audioStreamIndex, subtitleStreamIndex, liveStreamId) {
+
+    if (!item.userId) {
+        throw new Error("null userId");
+        return;
+    }
+
+    if (!item.serverAddress) {
+        throw new Error("null serverAddress");
+        return;
+    }
+
+    var postData = {
+        DeviceProfile: deviceProfile
     };
 
-    factory.reportPlaybackStart = function ($scope, options) {
-
-        this.stopDynamicContent();
-
-        if (!$scope.userId) {
-            throw new Error("null userId");
-        }
-
-        if (!$scope.serverAddress) {
-            throw new Error("null serverAddress");
-        }
-
-        var url = getUrl($scope.serverAddress, "Sessions/Playing");
-
-        broadcastToMessageBus({
-            type: 'playbackstart',
-            data: getSenderReportingData($scope, options)
-        });
-
-        restartPingInterval($scope, options);
-
-        return fetchhelper.ajax({
-
-            url: url,
-            headers: getSecurityHeaders($scope.accessToken, $scope.userId),
-            type: 'POST',
-            data: JSON.stringify(options),
-            contentType: 'application/json'
-        });
+    var query = {
+        UserId: item.userId,
+        StartTimeTicks: startPosition || 0,
+        MaxStreamingBitrate: maxBitrate
     };
 
-    factory.reportPlaybackProgress = function ($scope, options, reportToServer, broadcastEventName) {
+    if (audioStreamIndex != null) {
+        query.AudioStreamIndex = audioStreamIndex;
+    }
+    if (subtitleStreamIndex != null) {
+        query.SubtitleStreamIndex = subtitleStreamIndex;
+    }
+    if (mediaSourceId) {
+        query.MediaSourceId = mediaSourceId;
+    }
+    if (liveStreamId) {
+        query.LiveStreamId = liveStreamId;
+    }
 
-        if (!$scope.userId) {
-            throw new Error("null userId");
-        }
+    var url = getUrl(item.serverAddress, 'Items/' + item.Id + '/PlaybackInfo');
 
-        if (!$scope.serverAddress) {
-            throw new Error("null serverAddress");
-        }
+    return ajax({
 
-        //console.log(JSON.stringify(getSenderReportingData($scope, options)));
+        url: url,
+        headers: getSecurityHeaders(item.accessToken, item.userId),
+        query: query,
+        type: 'POST',
+        dataType: 'json',
+        data: JSON.stringify(postData),
+        contentType: 'application/json'
+    });
+};
 
-        broadcastToMessageBus({
-            type: broadcastEventName || 'playbackprogress',
-            data: getSenderReportingData($scope, options)
-        });
+factory.getLiveStream = function (item, playSessionId, maxBitrate, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex) {
 
-        if (reportToServer === false) {
-            return Promise.resolve();
-        }
+    if (!item.userId) {
+        throw new Error("null userId");
+        return;
+    }
 
-        var url = getUrl($scope.serverAddress, "Sessions/Playing/Progress");
+    if (!item.serverAddress) {
+        throw new Error("null serverAddress");
+        return;
+    }
 
-        restartPingInterval($scope, options);
-        lastTranscoderPing = new Date().getTime();
-
-        return fetchhelper.ajax({
-
-            url: url,
-            headers: getSecurityHeaders($scope.accessToken, $scope.userId),
-            type: 'POST',
-            data: JSON.stringify(options),
-            contentType: 'application/json'
-        });
+    var postData = {
+        DeviceProfile: deviceProfile,
+        OpenToken: mediaSource.OpenToken
     };
 
-    factory.reportPlaybackStopped = function ($scope, options) {
-
-        stopPingInterval();
-
-        if (!$scope.userId) {
-            throw new Error("null userId");
-        }
-
-        if (!$scope.serverAddress) {
-            throw new Error("null serverAddress");
-        }
-
-        var url = getUrl($scope.serverAddress, "Sessions/Playing/Stopped");
-
-        broadcastToMessageBus({
-            type: 'playbackstop',
-            data: getSenderReportingData($scope, options)
-        });
-
-        return fetchhelper.ajax({
-
-            url: url,
-            headers: getSecurityHeaders($scope.accessToken, $scope.userId),
-            type: 'POST',
-            data: JSON.stringify(options),
-            contentType: 'application/json'
-        });
+    var query = {
+        UserId: item.userId,
+        StartTimeTicks: startPosition || 0,
+        ItemId: item.Id,
+        MaxStreamingBitrate: maxBitrate,
+        PlaySessionId: playSessionId
     };
 
-    factory.pingTranscoder = function ($scope, options) {
+    if (audioStreamIndex != null) {
+        query.AudioStreamIndex = audioStreamIndex;
+    }
+    if (subtitleStreamIndex != null) {
+        query.SubtitleStreamIndex = subtitleStreamIndex;
+    }
 
-        if (!$scope.userId) {
-            throw new Error("null userId");
-        }
+    var url = getUrl(item.serverAddress, 'LiveStreams/Open');
 
-        if (!$scope.serverAddress) {
-            throw new Error("null serverAddress");
-        }
+    return ajax({
 
-        var now = new Date().getTime();
-        if ((now - lastTranscoderPing) < 10000) {
+        url: url,
+        headers: getSecurityHeaders(item.accessToken, item.userId),
+        query: query,
+        type: 'POST',
+        dataType: 'json',
+        data: JSON.stringify(postData),
+        contentType: 'application/json'
+    });
+};
 
-            console.log("Skipping ping due to recent progress check-in");
-            return new Promise(function (resolve, reject) {
-                resolve();
+factory.getDownloadSpeed = function ($scope, byteSize) {
+
+    if (!$scope.userId) {
+        throw new Error("null userId");
+    }
+
+    if (!$scope.serverAddress) {
+        throw new Error("null serverAddress");
+    }
+
+    var url = getUrl($scope.serverAddress, "Playback/BitrateTest");
+    url += "?size=" + byteSize;
+
+    var now = new Date().getTime();
+
+    return ajax({
+
+        type: "GET",
+        url: url,
+        headers: getSecurityHeaders($scope.accessToken, $scope.userId),
+        timeout: 5000
+
+    }).then(function () {
+
+        var responseTimeSeconds = (new Date().getTime() - now) / 1000;
+        var bytesPerSecond = byteSize / responseTimeSeconds;
+        var bitrate = Math.round(bytesPerSecond * 8);
+
+        return bitrate;
+    });
+};
+
+factory.detectBitrate = function ($scope) {
+
+    // First try a small amount so that we don't hang up their mobile connection
+    return factory.getDownloadSpeed($scope, 1000000).then(function (bitrate) {
+
+        if (bitrate < 1000000) {
+            return Math.round(bitrate * .8);
+        } else {
+
+            // If that produced a fairly high speed, try again with a larger size to get a more accurate result
+            return factory.getDownloadSpeed($scope, 2400000).then(function (bitrate) {
+
+                return Math.round(bitrate * .8);
             });
         }
 
-        var url = getUrl($scope.serverAddress, "Sessions/Playing/Ping");
-        lastTranscoderPing = new Date().getTime();
+    });
+};
 
-        return fetchhelper.ajax({
+factory.stopActiveEncodings = function ($scope) {
 
-            url: url,
-            headers: getSecurityHeaders($scope.accessToken, $scope.userId),
-            type: 'POST',
-            data: JSON.stringify(options),
-            contentType: 'application/json'
-        });
+    var options = {
+        deviceId: deviceInfo.deviceId
     };
 
-    var backdropInterval;
-    function clearBackropInterval() {
-        if (backdropInterval) {
-            clearInterval(backdropInterval);
-            backdropInterval = null;
-        }
+    if ($scope.playSessionId) {
+        options.PlaySessionId = $scope.playSessionId;
     }
 
-    function startBackdropInterval($scope, serverAddress, accessToken, userId) {
-
-        clearBackropInterval();
-
-        setRandomUserBackdrop($scope, serverAddress, accessToken, userId);
-
-        backdropInterval = setInterval(function () {
-            setRandomUserBackdrop($scope, serverAddress, accessToken, userId);
-        }, 30000);
-    }
-
-    function setRandomUserBackdrop($scope, serverAddress, accessToken, userId) {
-
-        console.log('setRandomUserBackdrop');
-
-        var url = getUrl(serverAddress, "Users/" + userId + "/Items");
-
-        fetchhelper.ajax({
-            url: url,
-            headers: getSecurityHeaders(accessToken, userId),
-            dataType: 'json',
-            type: 'GET',
-            query: {
-                SortBy: "Random",
-                IncludeItemTypes: "Movie,Series",
-                ImageTypes: 'Backdrop',
-                Recursive: true,
-
-                // Although we're limiting to what the user has access to,
-                // not everyone will want to see adult backdrops rotating on their TV.
-                MaxOfficialRating: 'PG-13',
-
-                Limit: 1
-            }
-
-        }).then(function (result) {
-            var item = result.Items[0];
-
-            var backdropUrl = '';
-
-            if (item) {
-                backdropUrl = getBackdropUrl(item, serverAddress) || '';
-            }
-
-            setWaitingBackdrop(backdropUrl);
-        });
-    }
-
-    factory.displayUserInfo = function ($scope, serverAddress, accessToken, userId) {
-
-        startBackdropInterval($scope, serverAddress, accessToken, userId);
-    };
-
-    factory.stopDynamicContent = function () {
-        clearBackropInterval();
-    };
-
-    function showItem($scope, serverAddress, accessToken, userId, item) {
-
-        clearBackropInterval();
-
-        console.log('showItem');
-
-        var backdropUrl = getBackdropUrl(item, serverAddress) || '';
-        var detailImageUrl = getPrimaryImageUrl(item, serverAddress) || '';
-
-        setAppStatus('details');
-        setWaitingBackdrop(backdropUrl);
-
-        setLogo(getLogoUrl(item, serverAddress) || '');
-        setOverview(item.Overview || '');
-        setGenres(item.Genres.join(' / '));
-        setDisplayName(getDisplayName(item));
-        document.getElementById('miscInfo').innerHTML = getMiscInfoHtml(item) || '';
-        document.getElementById('detailRating').innerHTML = getRatingHtml(item);
-
-        var playedIndicator = document.getElementById('playedIndicator');
-
-        if (item.UserData.Played) {
-
-            playedIndicator.style.display = 'block';
-            playedIndicator.innerHTML = '<span class="glyphicon glyphicon-ok"></span>';
-        }
-        else if (item.UserData.UnplayedItemCount) {
-
-            playedIndicator.style.display = 'block';
-            playedIndicator.innerHTML = item.UserData.UnplayedItemCount;
-        }
-        else {
-            playedIndicator.style.display = 'none';
-        }
-
-        if (item.UserData.PlayedPercentage && item.UserData.PlayedPercentage < 100 && !item.IsFolder) {
-            setHasPlayedPercentage(false);
-            setPlayedPercentage(item.UserData.PlayedPercentage);
-
-            detailImageUrl += "&PercentPlayed=" + parseInt(item.UserData.PlayedPercentage);
-
-        } else {
-            setHasPlayedPercentage(false);
-            setPlayedPercentage(0);
-        }
-
-        setDetailImage(detailImageUrl);
-    }
-
-    factory.displayItem = function ($scope, serverAddress, accessToken, userId, itemId) {
-
-        console.log('Displaying item: ' + itemId);
-
-        var url = getUrl(serverAddress, "Users/" + userId + "/Items/" + itemId);
-
-        fetchhelper.ajax({
-            url: url,
-            headers: getSecurityHeaders(accessToken, userId),
-            dataType: 'json',
-            type: 'GET'
-
-        }).then(function (item) {
-
-            showItem($scope, serverAddress, accessToken, userId, item);
-        });
-    };
-
-    factory.getSubtitle = function ($scope, subtitleStreamUrl) {
-
-        return fetchhelper.ajax({
-
-            url: subtitleStreamUrl,
-            headers: getSecurityHeaders($scope.accessToken, $scope.userId),
-            type: 'GET',
-            dataType: 'json'
-        });
-    };
-
-    factory.load = function ($scope, customData, serverItem) {
-
-        resetPlaybackScope($scope);
-
-        extend($scope, customData);
-
-        var data = serverItem;
-
-        $scope.item = data;
-
-        setAppStatus('backdrop');
-        $scope.mediaType = data.MediaType;
-    };
-
-    factory.play = function ($scope, event) {
-        if ($scope.status == 'backdrop' || $scope.status == 'playing-with-controls' || $scope.status == 'playing' || $scope.status == 'audio') {
-            setTimeout(function () {
-
-                var startTime = new Date();
-                window.mediaManager.play();
-
-                setAppStatus('playing-with-controls');
-                if ($scope.mediaType == "Audio") {
-                    setAppStatus('audio');
-                }
-            }, 20);
-        }
-    };
-
-    factory.stop = function ($scope) {
-
-        setTimeout(function () {
-            setAppStatus('waiting');
-        }, 20);
-    };
-
-    factory.getPlaybackInfo = function (item, maxBitrate, deviceProfile, startPosition, mediaSourceId, audioStreamIndex, subtitleStreamIndex, liveStreamId) {
-
-        if (!item.userId) {
-            throw new Error("null userId");
-            return;
-        }
-
-        if (!item.serverAddress) {
-            throw new Error("null serverAddress");
-            return;
-        }
-
-        var postData = {
-            DeviceProfile: deviceProfile
-        };
-
-        var query = {
-            UserId: item.userId,
-            StartTimeTicks: startPosition || 0,
-            MaxStreamingBitrate: maxBitrate
-        };
-
-        if (audioStreamIndex != null) {
-            query.AudioStreamIndex = audioStreamIndex;
-        }
-        if (subtitleStreamIndex != null) {
-            query.SubtitleStreamIndex = subtitleStreamIndex;
-        }
-        if (mediaSourceId) {
-            query.MediaSourceId = mediaSourceId;
-        }
-        if (liveStreamId) {
-            query.LiveStreamId = liveStreamId;
-        }
-
-        var url = getUrl(item.serverAddress, 'Items/' + item.Id + '/PlaybackInfo');
-
-        return fetchhelper.ajax({
-
-            url: url,
-            headers: getSecurityHeaders(item.accessToken, item.userId),
-            query: query,
-            type: 'POST',
-            dataType: 'json',
-            data: JSON.stringify(postData),
-            contentType: 'application/json'
-        });
-    };
-
-    factory.getLiveStream = function (item, playSessionId, maxBitrate, deviceProfile, startPosition, mediaSource, audioStreamIndex, subtitleStreamIndex) {
-
-        if (!item.userId) {
-            throw new Error("null userId");
-            return;
-        }
-
-        if (!item.serverAddress) {
-            throw new Error("null serverAddress");
-            return;
-        }
-
-        var postData = {
-            DeviceProfile: deviceProfile,
-            OpenToken: mediaSource.OpenToken
-        };
-
-        var query = {
-            UserId: item.userId,
-            StartTimeTicks: startPosition || 0,
-            ItemId: item.Id,
-            MaxStreamingBitrate: maxBitrate,
-            PlaySessionId: playSessionId
-        };
-
-        if (audioStreamIndex != null) {
-            query.AudioStreamIndex = audioStreamIndex;
-        }
-        if (subtitleStreamIndex != null) {
-            query.SubtitleStreamIndex = subtitleStreamIndex;
-        }
-
-        var url = getUrl(item.serverAddress, 'LiveStreams/Open');
-
-        return fetchhelper.ajax({
-
-            url: url,
-            headers: getSecurityHeaders(item.accessToken, item.userId),
-            query: query,
-            type: 'POST',
-            dataType: 'json',
-            data: JSON.stringify(postData),
-            contentType: 'application/json'
-        });
-    };
-
-    factory.getDownloadSpeed = function ($scope, byteSize) {
-
-        if (!$scope.userId) {
-            throw new Error("null userId");
-        }
-
-        if (!$scope.serverAddress) {
-            throw new Error("null serverAddress");
-        }
-
-        var url = getUrl($scope.serverAddress, "Playback/BitrateTest");
-        url += "?size=" + byteSize;
-
-        var now = new Date().getTime();
-
-        return fetchhelper.ajax({
-
-            type: "GET",
-            url: url,
-            headers: getSecurityHeaders($scope.accessToken, $scope.userId),
-            timeout: 5000
-
-        }).then(function () {
-
-            var responseTimeSeconds = (new Date().getTime() - now) / 1000;
-            var bytesPerSecond = byteSize / responseTimeSeconds;
-            var bitrate = Math.round(bytesPerSecond * 8);
-
-            return bitrate;
-        });
-    };
-
-    factory.detectBitrate = function ($scope) {
-
-        // First try a small amount so that we don't hang up their mobile connection
-        return factory.getDownloadSpeed($scope, 1000000).then(function (bitrate) {
-
-            if (bitrate < 1000000) {
-                return Math.round(bitrate * .8);
-            } else {
-
-                // If that produced a fairly high speed, try again with a larger size to get a more accurate result
-                return factory.getDownloadSpeed($scope, 2400000).then(function (bitrate) {
-
-                    return Math.round(bitrate * .8);
-                });
-            }
-
-        });
-    };
-
-    factory.stopActiveEncodings = function ($scope) {
-
-        var options = {
-            deviceId: deviceInfo.deviceId
-        };
-
-        if ($scope.playSessionId) {
-            options.PlaySessionId = $scope.playSessionId;
-        }
-
-        var url = getUrl($scope.serverAddress, "Videos/ActiveEncodings");
-
-        return fetchhelper.ajax({
-            type: "DELETE",
-            headers: getSecurityHeaders($scope.accessToken, $scope.userId),
-            url: url,
-            query: options
-        });
-    };
-
-    return factory;
-});
+    var url = getUrl($scope.serverAddress, "Videos/ActiveEncodings");
+
+    return ajax({
+        type: "DELETE",
+        headers: getSecurityHeaders($scope.accessToken, $scope.userId),
+        url: url,
+        query: options
+    });
+};
+
+export default factory;


### PR DESCRIPTION
Temporarily copy fetchhelper and convert it to an ES6 module until we can migrate to `jellyfin-apiclient-javascript`

Convert jellyfinactions to ES6 module