### PR TITLE
fix bugs that were preventing successful casting

### DIFF
--- a/src/components/maincontroller.js
+++ b/src/components/maincontroller.js
@@ -34,7 +34,7 @@ window.mediaManager.addEventListener(cast.framework.events.category.CORE,
         console.log(event);
     });
 
-const playbackMgr = new playbackManager();
+const playbackMgr = new playbackManager(window.castReceiverContext, window.mediaManager);
 
 const playbackConfig = new cast.framework.PlaybackConfig();
 // Set the player to start playback as soon as there are five seconds of

--- a/src/components/playbackManager.js
+++ b/src/components/playbackManager.js
@@ -44,7 +44,7 @@ export class playbackManager {
             return;
         }
 
-        getIntros(firstItem.serverAddress, firstItem.accessToken, firstItem.userId, firstItem).then(function (intros) {
+        getIntros(firstItem.serverAddress, firstItem.accessToken, firstItem.userId, firstItem).then(intros => {
 
             tagItems(intros.Items, {
                 userId: firstItem.userId,
@@ -63,6 +63,8 @@ export class playbackManager {
 
         this.activePlaylist = options.items;
         this.activePlaylist.currentPlaylistIndex = -1;
+        window.playlist = this.activePlaylist;
+
         this.playNextItem(options, stopPlayer);
     }
 
@@ -114,11 +116,11 @@ export class playbackManager {
         $scope.isChangingStream = false;
         setAppStatus('loading');
 
-        getMaxBitrate(item.MediaType).then(function (maxBitrate) {
+        getMaxBitrate(item.MediaType).then(maxBitrate => {
 
             var deviceProfile = getDeviceProfile(maxBitrate);
 
-            jellyfinActions.getPlaybackInfo(item, maxBitrate, deviceProfile, options.startPositionTicks, options.mediaSourceId, options.audioStreamIndex, options.subtitleStreamIndex).then(function (result) {
+            jellyfinActions.getPlaybackInfo(item, maxBitrate, deviceProfile, options.startPositionTicks, options.mediaSourceId, options.audioStreamIndex, options.subtitleStreamIndex).then(result => {
 
                 if (validatePlaybackInfoResult(result)) {
 
@@ -128,7 +130,7 @@ export class playbackManager {
 
                         if (mediaSource.RequiresOpening) {
 
-                            jellyfinActions.getLiveStream(item, result.PlaySessionId, maxBitrate, deviceProfile, options.startPositionTicks, mediaSource, null, null).then(function (openLiveStreamResult) {
+                            jellyfinActions.getLiveStream(item, result.PlaySessionId, maxBitrate, deviceProfile, options.startPositionTicks, mediaSource, null, null).then(openLiveStreamResult => {
 
                                 openLiveStreamResult.MediaSource.enableDirectPlay = supportsDirectPlay(openLiveStreamResult.MediaSource);
                                 this.playMediaSource(result.PlaySessionId, item, openLiveStreamResult.MediaSource, options);


### PR DESCRIPTION
There are three main fixes in here:

maincontroller.js
- the `playbackMgr` object was not being constructed with its constructor parameters.

playbackmanager.js
- many callback functions were using `this.` inside unbound anonymous functions, and thus was hitting undefined references. fixed by using arrow functions instead.
- `getNextPlaybackItemInfo` was failing because it uses `window.playlist`, which was not being assigned by `playbackManager`. Since removing `window.playlist` will require more refactoring, I just assign it before calling the function.

These fixes allow casting to work successfully, including media control using the Google Home app:
![image](https://user-images.githubusercontent.com/791774/88632827-00b18980-d069-11ea-849a-caf7173f1d77.png)