### PR TITLE
A couple of fixes/changes

### DIFF
--- a/src/components/maincontroller.js
+++ b/src/components/maincontroller.js
@@ -233,7 +233,7 @@ export function processMessage(data) {
     let cmdHandler = window.commandHandler;
 
     if (!cmdHandler) {
-        window.commandHandler = new commandHandler(window.castReceiverContext, window.mediaManager);
+        window.commandHandler = new commandHandler(window.castReceiverContext, window.mediaManager, playbackMgr);
         cmdHandler = window.commandHandler;
     }
 

--- a/src/components/maincontroller.js
+++ b/src/components/maincontroller.js
@@ -134,6 +134,8 @@ mgr.addEventListener('PAUSE', mgr.defaultOnPause);
 mgr.defaultOnStop = function (event) {
     playbackMgr.stop();
 };
+
+mgr.addEventListener(cast.framework.events.EventType.MEDIA_FINISHED, mgr.defaultOnStop);
 mgr.addEventListener('ABORT', mgr.defaultOnStop);
 
 mgr.addEventListener('ENDED', function () {

--- a/src/components/maincontroller.js
+++ b/src/components/maincontroller.js
@@ -124,21 +124,21 @@ mgr.defaultOnPlay = function (event) {
     jellyfinActions.play($scope, event);
     jellyfinActions.reportPlaybackProgress($scope, getReportingParams($scope));
 };
-mgr.addEventListener('PLAY', mgr.defaultOnPlay);
+mgr.addEventListener(cast.framework.events.EventType.PLAY, mgr.defaultOnPlay);
 
 mgr.defaultOnPause = function (event) {
     jellyfinActions.reportPlaybackProgress($scope, getReportingParams($scope));
 };
-mgr.addEventListener('PAUSE', mgr.defaultOnPause);
+mgr.addEventListener(cast.framework.events.EventType.PAUSE, mgr.defaultOnPause);
 
 mgr.defaultOnStop = function (event) {
     playbackMgr.stop();
 };
 
 mgr.addEventListener(cast.framework.events.EventType.MEDIA_FINISHED, mgr.defaultOnStop);
-mgr.addEventListener('ABORT', mgr.defaultOnStop);
+mgr.addEventListener(cast.framework.events.EventType.ABORT, mgr.defaultOnStop);
 
-mgr.addEventListener('ENDED', function () {
+mgr.addEventListener(cast.framework.events.EventType.ENDED, function () {
 
     // Ignore
     if ($scope.isChangingStream) {


### PR DESCRIPTION
Use static event names from the cast framework for events in maincontroller.
Properly handle stop event. Now the player shouldn't be left stuck on the "Jellyfin" text with a backdrop related to the item after playback has stopped.
Fix missing argument for commandHandler. This caused a few undefined reference errors previously.