### PR TITLE
Limit flac to 96kHz 24bit

### DIFF
--- a/src/components/deviceprofilebuilder.js
+++ b/src/components/deviceprofilebuilder.js
@@ -171,6 +171,15 @@ function getCodecProfiles() {
                 createProfileCondition("IsSecondaryAudio", "Equals", false)
             ]
         });
+
+        CodecProfiles.push({
+            Type: "Audio",
+            Codec: "flac",
+            Conditions: [
+                createProfileCondition("AudioSampleRate", "LessThanEqual", "96000"),
+                createProfileCondition("AudioBitDepth", "LessThanEqual", "24")
+            ]
+        });
     }
 
     return CodecProfiles;


### PR DESCRIPTION
96kHz 24bit is the maximum supported for FLAC by CAF
https://developers.google.com/cast/docs/media