### PR TITLE
Fix playbackInfo request failing with HTTP error 400

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ide
 .idea
 .vscode
+tags
 
 # npm/yarn
 node_modules

--- a/src/components/deviceprofilebuilder.js
+++ b/src/components/deviceprofilebuilder.js
@@ -29,7 +29,7 @@ let currentDeviceId;
 /**
  * @param {string} Property What property the condition should test.
  * @param {string} Condition The condition to test the values for.
- * @param {(string|number)} Value The value to compare against.
+ * @param {(boolean|string|number)} Value The value to compare against.
  * @param {boolean} [IsRequired=false]
  * @returns {Object} A profile condition created from the parameters.
  */
@@ -37,7 +37,7 @@ function createProfileCondition(Property, Condition, Value, IsRequired = false) 
     return {
         Condition,
         Property,
-        Value,
+        Value: Value.toString(),
         IsRequired
     }
 }


### PR DESCRIPTION
The server does not seem to like boolean or number values in the value field of `CodecProfile` conditions anymore. This converts all of them to strings.

Tested with fixes from jellyfin/jellyfin#4173 applied