### PR TITLE
Fix playlist index always set to 0

### DIFF
--- a/src/components/maincontroller.js
+++ b/src/components/maincontroller.js
@@ -35,6 +35,7 @@ window.mediaManager.addEventListener(cast.framework.events.category.CORE,
     });
 
 const playbackMgr = new playbackManager(window.castReceiverContext, window.mediaManager);
+window.playbackManager = playbackMgr;
 
 const playbackConfig = new cast.framework.PlaybackConfig();
 // Set the player to start playback as soon as there are five seconds of

--- a/src/components/playbackManager.js
+++ b/src/components/playbackManager.js
@@ -29,7 +29,7 @@ export class playbackManager {
 
         // Properties
         this.activePlaylist = [];
-        this.activePlaylistIndex = 0;
+        this.activePlaylistIndex = -1;
     }
 
     isPlaying() {
@@ -62,7 +62,7 @@ export class playbackManager {
         var stopPlayer = this.activePlaylist && this.activePlaylist.length > 0;
 
         this.activePlaylist = options.items;
-        this.activePlaylist.currentPlaylistIndex = -1;
+        this.activePlaylistIndex = options.startIndex || -1;
         window.playlist = this.activePlaylist;
 
         this.playNextItem(options, stopPlayer);
@@ -70,7 +70,6 @@ export class playbackManager {
 
     // Plays the next item in the list
     playNextItem(options, stopPlayer) {
-
         var nextItemInfo = getNextPlaybackItemInfo();
 
         if (nextItemInfo) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -52,30 +52,31 @@ export function getReportingParams($scope) {
 
 export function getNextPlaybackItemInfo() {
 
-    var playlist = window.playlist;
+    var playlist = window.playbackManager.activePlaylist;
 
     if (!playlist) {
         return null;
     }
 
+    let activeIndex = window.playbackManager.activePlaylistIndex;
     var newIndex;
 
-    if (window.currentPlaylistIndex == -1) {
+    if (activeIndex == -1) {
         newIndex = 0;
     } else {
         switch (window.repeatMode) {
 
             case 'RepeatOne':
-                newIndex = window.currentPlaylistIndex;
+                newIndex = activeIndex;
                 break;
             case 'RepeatAll':
-                newIndex = window.currentPlaylistIndex + 1;
-                if (newIndex >= window.playlist.length) {
+                newIndex = activeIndex + 1;
+                if (newIndex >= playlist.length) {
                     newIndex = 0;
                 }
                 break;
             default:
-                newIndex = window.currentPlaylistIndex + 1;
+                newIndex = activeIndex;
                 break;
         }
     }


### PR DESCRIPTION
Previously playlist index was always set to 0 before playback started, which caused playlists (and albums) to start from the beginning.

Fixes #54 