### PR TITLE
Filtered set of the various fixes PR

### DIFF
--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -58,6 +58,7 @@ export function hasVP9Support(): boolean {
 export function getMaxBitrateSupport(): number {
     // FIXME: We should get this dynamically or hardcode this to values
     // we see fit for each Cast device. More testing is needed.
+    // 120Mb/s ?
     return 120000000;
 }
 

--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -2,6 +2,18 @@ import { deviceIds } from './castDevices';
 
 const castContext = cast.framework.CastReceiverContext.getInstance();
 
+export function hasEAC3Support(): boolean {
+    return castContext.canDisplayType('audio/mp4', 'ec-3');
+}
+
+export function hasAC3Support(): boolean {
+    return castContext.canDisplayType('audio/mp4', 'ac-3');
+}
+
+export function hasSurroundSupport(): boolean {
+    return hasAC3Support();
+}
+
 export function hasH265Support(): boolean {
     return castContext.canDisplayType('video/mp4', 'hev1.1.6.L150.B0');
 }
@@ -121,7 +133,16 @@ export function getSupportedMP4VideoCodecs(): Array<string> {
  * @returns Supported MP4 audio codecs.
  */
 export function getSupportedMP4AudioCodecs(): Array<string> {
-    return ['aac', 'mp3'];
+    const codecs = [];
+    if (hasEAC3Support()) {
+        codecs.push('eac3');
+    }
+    if (hasAC3Support()) {
+        codecs.push('ac3');
+    }
+    codecs.push('aac');
+    codecs.push('mp3');
+    return codecs;
 }
 
 /**

--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -3,15 +3,36 @@ import { deviceIds } from './castDevices';
 const castContext = cast.framework.CastReceiverContext.getInstance();
 
 export function hasEAC3Support(): boolean {
-    return castContext.canDisplayType('audio/mp4', 'ec-3');
+    // Some error causes this not to work at all
+    //return castContext.canDisplayType('audio/mp4', 'ec-3');
+    return false;
 }
 
 export function hasAC3Support(): boolean {
-    return castContext.canDisplayType('audio/mp4', 'ac-3');
+    // Some error causes this not to work at all
+    //return castContext.canDisplayType('audio/mp4', 'ac-3');
+    return false;
 }
 
-export function hasSurroundSupport(): boolean {
+export function hasSurroundSupport(deviceId: number): boolean {
+    // AC-3 in this client is broken. The cause is not known yet.
+    // However, the device does report correctly in this check.
+    // We can use that to estimate if we can send AAC 6ch.
+
+    // From my testing:
+    // GEN1+GEN2+GEN3 can only do 2.0 when AC3 is lacking.
+    // AUDIO has toslink at most, which doesn't do pcm 6ch.
+    // Forums indicate that they only support the passthrough option across the lineup.
+    // See https://support.google.com/chromecast/thread/362511
+
+    // This will turn on surround support if passthrough is available.
     return hasAC3Support();
+
+    // If there are cast devices that can decode 6ch audio:
+    // We cannot check if the connected system supports pcm 6ch, but we can check for ac-3.
+    // Sadly there are some situations (toslink) that supports ac-3 but not pcm 6ch.
+    // In those cases we will rely on chromecast downmixing.
+    //return castContext.canDisplayType('audio/mp4', 'ac-3');
 }
 
 export function hasH265Support(): boolean {

--- a/src/components/commandHandler.ts
+++ b/src/components/commandHandler.ts
@@ -36,6 +36,7 @@ export class commandHandler {
     private playbackManager: playbackManager;
     private supportedCommands: SupportedCommands = {
         PlayNext: this.playNextHandler,
+        PlayNow: this.playNowHandler,
         PlayLast: this.playLastHandler,
         Shuffle: this.shuffleHandler,
         InstantMix: this.instantMixHandler,
@@ -70,6 +71,10 @@ export class commandHandler {
     }
 
     playNextHandler(data: DataMessage): void {
+        translateItems(data, data.options, data.options.items, data.command);
+    }
+
+    playNowHandler(data: DataMessage): void {
         translateItems(data, data.options, data.options.items, data.command);
     }
 
@@ -215,7 +220,7 @@ export class commandHandler {
             );
             commandHandler.bind(this)(data);
         } else {
-            console.debug(
+            console.log(
                 `Command "${command}" received. Could not identify handler, calling default handler.`
             );
             this.defaultHandler(data);

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -267,7 +267,7 @@ function getTranscodingProfiles(): Array<TranscodingProfile> {
     const TranscodingProfiles: Array<TranscodingProfile> = [];
 
     const hlsAudioCodecs = getSupportedHLSAudioCodecs();
-    const audioChannels: number = hasSurroundSupport() ? 6 : 2;
+    const audioChannels: number = hasSurroundSupport(currentDeviceId) ? 6 : 2;
 
     if (profileOptions.enableHls !== false) {
         TranscodingProfiles.push({

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -33,8 +33,8 @@ import {
 } from './codecSupportHelper';
 
 interface ProfileOptions {
-    audioChannels?: number;
-    enableHls?: boolean;
+    audioChannels: number;
+    enableHls: boolean;
     bitrateSetting?: number;
 }
 

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -35,7 +35,7 @@ import {
 
 interface ProfileOptions {
     enableHls: boolean;
-    bitrateSetting?: number;
+    bitrateSetting: number;
 }
 
 let profileOptions: ProfileOptions;
@@ -367,13 +367,14 @@ export function getDeviceProfile(options: ProfileOptions): DeviceProfile {
     profileOptions = options;
     currentDeviceId = getActiveDeviceId();
 
-    const bitrateSetting = options.bitrateSetting || getMaxBitrateSupport();
-
     // MaxStaticBitrate seems to be for offline sync only
     const profile: DeviceProfile = {
-        MaxStreamingBitrate: bitrateSetting,
-        MaxStaticBitrate: 0,
-        MusicStreamingTranscodingBitrate: Math.min(bitrateSetting, 192000)
+        MaxStreamingBitrate: options.bitrateSetting,
+        MaxStaticBitrate: options.bitrateSetting,
+        MusicStreamingTranscodingBitrate: Math.min(
+            options.bitrateSetting,
+            192000
+        )
     };
 
     profile.DirectPlayProfiles = getDirectPlayProfiles();

--- a/src/components/maincontroller.js
+++ b/src/components/maincontroller.js
@@ -31,6 +31,8 @@ import {
     tagItems
 } from '../helpers';
 
+import { getMaxBitrateSupport } from './codecSupportHelper';
+
 import { commandHandler } from './commandHandler';
 import { playbackManager } from './playbackManager';
 
@@ -222,7 +224,7 @@ window.mediaManager.addEventListener(
 console.log('Application is ready, starting system');
 
 export function reportDeviceCapabilities() {
-    getMaxBitrate('Video').then((maxBitrate) => {
+    getMaxBitrate().then((maxBitrate) => {
         let capabilitiesUrl =
             $scope.serverAddress + '/Sessions/Capabilities/Full';
         let deviceProfile = getDeviceProfile(maxBitrate);
@@ -422,9 +424,8 @@ export function changeStream(ticks, params) {
     var liveStreamId = $scope.liveStreamId;
 
     var item = $scope.item;
-    var mediaType = item.MediaType;
 
-    getMaxBitrate(mediaType).then(async (maxBitrate) => {
+    getMaxBitrate().then(async (maxBitrate) => {
         const deviceProfile = getDeviceProfile(maxBitrate);
         const audioStreamIndex =
             params.AudioStreamIndex == null
@@ -585,10 +586,11 @@ export function getDeviceProfile(maxBitrate) {
 
 var lastBitrateDetect = 0;
 var detectedBitrate = 0;
-export function getMaxBitrate(mediaType) {
+export function getMaxBitrate() {
     console.log('getMaxBitrate');
 
     return new Promise(function (resolve, reject) {
+        // The client can set this number
         if (window.MaxBitrate) {
             console.log('bitrate is set to ' + window.MaxBitrate);
 
@@ -607,12 +609,6 @@ export function getMaxBitrate(mediaType) {
             return;
         }
 
-        if (mediaType != 'Video') {
-            // We don't need to bother with bitrate detection for music
-            resolve(window.DefaultMaxBitrate);
-            return;
-        }
-
         console.log('detecting bitrate');
 
         detectBitrate($scope).then(
@@ -625,9 +621,9 @@ export function getMaxBitrate(mediaType) {
             },
             function () {
                 console.log(
-                    'Error detecting bitrate, will return default value.'
+                    'Error detecting bitrate, will return device maximum.'
                 );
-                resolve(window.DefaultMaxBitrate);
+                resolve(getMaxBitrateSupport());
             }
         );
     });

--- a/src/components/maincontroller.js
+++ b/src/components/maincontroller.js
@@ -586,8 +586,9 @@ export function getDeviceProfile(maxBitrate) {
         : 2;
 
     return deviceProfileBuilder({
-        supportsCustomSeeking: true,
-        audioChannels: transcodingAudioChannels
+        audioChannels: transcodingAudioChannels,
+        enableHls: true,
+        bitrateSetting: maxBitrate
     });
 }
 

--- a/src/components/maincontroller.js
+++ b/src/components/maincontroller.js
@@ -577,15 +577,7 @@ export function onStopPlayerBeforePlaybackDone(item, options) {
 }
 
 export function getDeviceProfile(maxBitrate) {
-    let transcodingAudioChannels = document
-        .createElement('video')
-        .canPlayType('audio/mp4; codecs="ac-3"')
-        .replace(/no/, '')
-        ? 6
-        : 2;
-
     return deviceProfileBuilder({
-        audioChannels: transcodingAudioChannels,
         enableHls: true,
         bitrateSetting: maxBitrate
     });

--- a/src/components/maincontroller.js
+++ b/src/components/maincontroller.js
@@ -484,8 +484,6 @@ export function changeStream(ticks, params) {
 window.castReceiverContext.addCustomMessageListener(
     'urn:x-cast:com.connectsdk',
     function (evt) {
-        console.log('Playlist message: ' + JSON.stringify(evt));
-
         var data = evt.data;
 
         // Apparently chromium likes to pass it as json, not as object.
@@ -500,6 +498,7 @@ window.castReceiverContext.addCustomMessageListener(
         // TODO set it somewhere better perhaps
         window.senderId = evt.senderId;
 
+        console.log('Received message: ' + JSON.stringify(data));
         processMessage(data);
     }
 );

--- a/src/components/playbackManager.js
+++ b/src/components/playbackManager.js
@@ -197,7 +197,7 @@ export class playbackManager {
         if (item.BackdropImageTags && item.BackdropImageTags.length) {
             backdropUrl =
                 $scope.serverAddress +
-                '/emby/Items/' +
+                '/Items/' +
                 item.Id +
                 '/Images/Backdrop/0?tag=' +
                 item.BackdropImageTags[0];
@@ -208,7 +208,7 @@ export class playbackManager {
         ) {
             backdropUrl =
                 $scope.serverAddress +
-                '/emby/Items/' +
+                '/Items/' +
                 item.ParentBackdropItemId +
                 '/Images/Backdrop/0?tag=' +
                 item.ParentBackdropImageTags[0];

--- a/src/components/playbackManager.js
+++ b/src/components/playbackManager.js
@@ -120,7 +120,7 @@ export class playbackManager {
         $scope.isChangingStream = false;
         setAppStatus('loading');
 
-        const maxBitrate = await getMaxBitrate(item.MediaType);
+        const maxBitrate = await getMaxBitrate();
         const deviceProfile = getDeviceProfile(maxBitrate);
         const playbackInfo = await getPlaybackInfo(
             item,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -354,7 +354,7 @@ export function createStreamInfo(item, mediaSource, startPosition) {
         } else if (mediaSource.SupportsDirectStream) {
             mediaUrl = getUrl(
                 item.serverAddress,
-                'Videos/' + item.Id + '/stream.' + mediaSource.Container
+                'videos/' + item.Id + '/stream.' + mediaSource.Container
             );
             mediaUrl += '?mediaSourceId=' + mediaSource.Id;
             mediaUrl += '&api_key=' + item.accessToken;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -222,28 +222,28 @@ export function getMetadata(item) {
     if (item.SeriesPrimaryImageTag) {
         posterUrl =
             $scope.serverAddress +
-            '/emby/Items/' +
+            '/Items/' +
             item.SeriesId +
             '/Images/Primary?tag=' +
             item.SeriesPrimaryImageTag;
     } else if (item.AlbumPrimaryImageTag) {
         posterUrl =
             $scope.serverAddress +
-            '/emby/Items/' +
+            '/Items/' +
             item.AlbumId +
             '/Images/Primary?tag=' +
             item.AlbumPrimaryImageTag;
     } else if (item.PrimaryImageTag) {
         posterUrl =
             $scope.serverAddress +
-            '/emby/Items/' +
+            '/Items/' +
             item.Id +
             '/Images/Primary?tag=' +
             item.PrimaryImageTag;
     } else if (item.ImageTags.Primary) {
         posterUrl =
             $scope.serverAddress +
-            '/emby/Items/' +
+            '/Items/' +
             item.Id +
             '/Images/Primary?tag=' +
             item.ImageTags.Primary;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -439,15 +439,13 @@ export function createStreamInfo(item, mediaSource, startPosition) {
     var subtitleTracks = [];
     subtitleStreams.forEach(function (subtitleStream) {
         let subStreamCodec = subtitleStream.Codec.toLowerCase();
-        if (
-            subStreamCodec !== 'vtt' &&
-            subStreamCodec !== 'webvtt' &&
-            subStreamCodec === 'srt' &&
-            subtitleStream.DeliveryMethod !== 'External'
-        ) {
+        if (subtitleStream.DeliveryUrl === undefined) {
             /* The CAF v3 player only supports vtt currently,
-            SRT subs can be "transcoded" to vtt by jellyfin.
-            Support for more could be added with a custom implementation */
+             * SRT subs can be "transcoded" to vtt by jellyfin.
+             * The server will do that in accordance with the device profiles and
+             * give us a DeliveryUrl if that is the case.
+             * Support for more could be added with a custom implementation
+             **/
             return;
         }
         var textStreamUrl = subtitleStream.IsExternalUrl

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -467,9 +467,7 @@ export function createStreamInfo(item, mediaSource, startPosition) {
         console.log('Subtitle url: ' + info.subtitleStreamUrl);
     });
 
-    if (subtitleTracks) {
-        info.tracks = subtitleTracks;
-    }
+    info.tracks = subtitleTracks;
 
     return info;
 }


### PR DESCRIPTION
The ones I think are actually useful. Messing around with logging and dev mode idle timeout was too messy for this round.

* Fix the subtitle check
* Remove emby references in URLs, lowercase /Videos/ to /videos/ in the directstream case
    * (I wish we could agree on a best practice of using the lowercase variants. The server seems case insensitive.)
* Add PlayNow command handler, increase verbosity of default handler invocations
* Start supporting AC-3 and E-AC-3, but disable it in codecSupportHelper because CAF is broken (it seems)
    * Clean up deviceProfile call, make arguments mandatory. Move the ac-3 check to codecSupportHelper.
    * Now everyone gets 2ch aac... Can someone show me 6ch aac working? Does that work on any chromecast?
* Clean up the max bitrate code because it was transcoding due to exceeded bandwidth when that was false.