### PR TITLE
Add tests to credentialManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "prepare": "npm run build:production",
         "prettier": "prettier --check .",
         "start": "TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack serve --config webpack.config.ts",
-        "test": "jest --passWithNoTests",
+        "test": "jest",
         "watch": "TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack --config webpack.config.ts --watch"
     }
 }

--- a/src/__tests__/credentialManager.test.ts
+++ b/src/__tests__/credentialManager.test.ts
@@ -1,0 +1,88 @@
+import { Configuration } from "../api/generated/configuration";
+
+import {
+    credentialManager,
+    CredentialStore
+} from "../api/credentialManager";
+
+const serverId1 = "f4486b851af24255b3305fe614b81f01";
+const serverConfig1: Configuration = {
+    apiKey: "b49268e51af24255b3305fe614b81f01"
+};
+
+const serverId2 = "af72hb851af24255b3305fe614b81f01";
+const serverConfig2: Configuration = {
+    apiKey: "d4286b8119f24a55b3305fe614b81f01"
+};
+
+describe("Getting servers from credentialManager", () => {
+    let credentialMgr: credentialManager;
+
+    beforeEach(() => {
+        credentialMgr = new credentialManager({
+            [serverId1]: serverConfig1
+        });
+    });
+
+    test("Get existing server from store", () => {
+        expect(credentialMgr.get(serverId1)).toEqual(serverConfig1);
+    });
+
+    test("Get non-existant server from store", () => {
+        expect(credentialMgr.get(serverId2)).toBeUndefined();
+    });
+});
+
+describe("Updating servers in credentialManager", () => {
+    let credentialMgr: credentialManager;
+
+    beforeEach(() => {
+        credentialMgr = new credentialManager({
+            [serverId1]: serverConfig1
+        });
+    });
+
+    test("Update existing server in store", () => {
+        expect(credentialMgr.update(serverId1, serverConfig1)).toBeTruthy();
+    });
+
+    test("Update non-existant server in store", () => {
+        expect(credentialMgr.update(serverId2, serverConfig2)).toBeFalsy();
+    });
+});
+
+describe("Adding servers to credentialManager", () => {
+    let credentialMgr: credentialManager;
+
+    beforeEach(() => {
+        credentialMgr = new credentialManager({
+            [serverId1]: serverConfig1
+        });
+    });
+
+    test("Add server id to store", () => {
+        expect(credentialMgr.add(serverId2, serverConfig2)).toBeTruthy();
+    });
+
+    test("Add existing server configuration to store", () => {
+        expect(credentialMgr.add(serverId1, serverConfig1)).toBeFalsy();
+    });
+});
+
+describe("Removing server from credentialManager", () => {
+    let credentialMgr: credentialManager;
+
+    beforeEach(() => {
+        credentialMgr = new credentialManager({
+            [serverId1]: serverConfig1
+        });
+    });
+
+    test("Remove existing server from store", () => {
+        expect(credentialMgr.remove(serverId1)).toBeTruthy();
+    });
+
+    test("Remove non-existant server from store", () => {
+        expect(credentialMgr.remove(serverId2)).toBeFalsy();
+    });
+});

--- a/src/__tests__/credentialManager.test.ts
+++ b/src/__tests__/credentialManager.test.ts
@@ -1,6 +1,6 @@
 import { Configuration } from '../api/generated/configuration';
 
-import { credentialManager, CredentialStore } from '../api/credentialManager';
+import { credentialManager } from '../api/credentialManager';
 
 const serverId1 = 'f4486b851af24255b3305fe614b81f01';
 const serverConfig1: Configuration = {

--- a/src/__tests__/credentialManager.test.ts
+++ b/src/__tests__/credentialManager.test.ts
@@ -1,21 +1,18 @@
-import { Configuration } from "../api/generated/configuration";
+import { Configuration } from '../api/generated/configuration';
 
-import {
-    credentialManager,
-    CredentialStore
-} from "../api/credentialManager";
+import { credentialManager, CredentialStore } from '../api/credentialManager';
 
-const serverId1 = "f4486b851af24255b3305fe614b81f01";
+const serverId1 = 'f4486b851af24255b3305fe614b81f01';
 const serverConfig1: Configuration = {
-    apiKey: "b49268e51af24255b3305fe614b81f01"
+    apiKey: 'b49268e51af24255b3305fe614b81f01'
 };
 
-const serverId2 = "af72hb851af24255b3305fe614b81f01";
+const serverId2 = 'af72hb851af24255b3305fe614b81f01';
 const serverConfig2: Configuration = {
-    apiKey: "d4286b8119f24a55b3305fe614b81f01"
+    apiKey: 'd4286b8119f24a55b3305fe614b81f01'
 };
 
-describe("Getting servers from credentialManager", () => {
+describe('getting servers from credentialManager', () => {
     let credentialMgr: credentialManager;
 
     beforeEach(() => {
@@ -24,16 +21,16 @@ describe("Getting servers from credentialManager", () => {
         });
     });
 
-    test("Get existing server from store", () => {
+    test('get existing server from store', () => {
         expect(credentialMgr.get(serverId1)).toEqual(serverConfig1);
     });
 
-    test("Get non-existant server from store", () => {
+    test('get non-existant server from store', () => {
         expect(credentialMgr.get(serverId2)).toBeUndefined();
     });
 });
 
-describe("Updating servers in credentialManager", () => {
+describe('updating servers in credentialManager', () => {
     let credentialMgr: credentialManager;
 
     beforeEach(() => {
@@ -42,16 +39,16 @@ describe("Updating servers in credentialManager", () => {
         });
     });
 
-    test("Update existing server in store", () => {
+    test('update existing server in store', () => {
         expect(credentialMgr.update(serverId1, serverConfig1)).toBeTruthy();
     });
 
-    test("Update non-existant server in store", () => {
+    test('update non-existant server in store', () => {
         expect(credentialMgr.update(serverId2, serverConfig2)).toBeFalsy();
     });
 });
 
-describe("Adding servers to credentialManager", () => {
+describe('adding servers to credentialManager', () => {
     let credentialMgr: credentialManager;
 
     beforeEach(() => {
@@ -60,16 +57,16 @@ describe("Adding servers to credentialManager", () => {
         });
     });
 
-    test("Add server id to store", () => {
+    test('add server id to store', () => {
         expect(credentialMgr.add(serverId2, serverConfig2)).toBeTruthy();
     });
 
-    test("Add existing server configuration to store", () => {
+    test('add existing server configuration to store', () => {
         expect(credentialMgr.add(serverId1, serverConfig1)).toBeFalsy();
     });
 });
 
-describe("Removing server from credentialManager", () => {
+describe('removing server from credentialManager', () => {
     let credentialMgr: credentialManager;
 
     beforeEach(() => {
@@ -78,11 +75,11 @@ describe("Removing server from credentialManager", () => {
         });
     });
 
-    test("Remove existing server from store", () => {
+    test('remove existing server from store', () => {
         expect(credentialMgr.remove(serverId1)).toBeTruthy();
     });
 
-    test("Remove non-existant server from store", () => {
+    test('remove non-existant server from store', () => {
         expect(credentialMgr.remove(serverId2)).toBeFalsy();
     });
 });

--- a/src/api/credentialManager.ts
+++ b/src/api/credentialManager.ts
@@ -7,11 +7,14 @@ interface CredentialStore {
 export class credentialManager {
     /**
      * Store for credentials
+     *
      * @private
      */
     private credentialStore: CredentialStore;
 
     /**
+     * Default constructor for credentialManager.
+     *
      * @param initialStore - Existing CredentialStore to initialize private store with.
      */
     constructor(initialStore: CredentialStore = {}) {
@@ -20,9 +23,10 @@ export class credentialManager {
 
     /**
      * Get credentials for the provided server ID.
+     *
      * @param serverId - ID of the server the credentials belong to.
-     * @returns Credentials for the provided server ID
-     *      or undefined if the store has no server with that ID.
+     * @returns Credentials for the provided server ID.
+     * or undefined if the store has no server with that ID.
      */
     get(serverId: string): Configuration | undefined {
         if (serverId in this.credentialStore) {
@@ -31,7 +35,8 @@ export class credentialManager {
     }
 
     /**
-     * Update credentials for the provided server ID
+     * Update credentials for the provided server ID.
+     *
      * @param serverId - ID of the server to update.
      * @param newConfig - Updated Credentials.
      * @returns True if the value was updated, false if it wasn't.
@@ -48,8 +53,9 @@ export class credentialManager {
 
     /**
      * Add a new credential to store. Only accepts new entries.
+     *
      * @param serverId - ID of the server the credentials belong to.
-     * @param Configuration - Credentials of the server.
+     * @param configuration - Credentials of the server.
      * @returns True if server was added, false if it wasn't.
      */
     add(serverId: string, configuration: Configuration): boolean {
@@ -64,13 +70,15 @@ export class credentialManager {
 
     /**
      * Remove a credential from store.
+     *
      * @param serverId - ID of the server the credentials belong to.
      * @returns True if server was removed, false if it wasn't.
      */
     remove(serverId: string): boolean {
         if (serverId in this.credentialStore) {
-            delete this.credentialStore[serverId]
-            return true
+            delete this.credentialStore[serverId];
+
+            return true;
         }
 
         return false;

--- a/src/api/credentialManager.ts
+++ b/src/api/credentialManager.ts
@@ -7,16 +7,22 @@ interface CredentialStore {
 export class credentialManager {
     /**
      * Store for credentials
-     *
      * @private
      */
-    private credentialStore: CredentialStore = {};
+    private credentialStore: CredentialStore;
 
     /**
-     * Get credentials for the provided server ID
-     *
-     * @param serverId - ID of the server the credentials belong to
-     * @returns Credentials for the provided server ID or undefined if the store has no server with that ID
+     * @param initialStore - Existing CredentialStore to initialize private store with.
+     */
+    constructor(initialStore: CredentialStore = {}) {
+        this.credentialStore = initialStore;
+    }
+
+    /**
+     * Get credentials for the provided server ID.
+     * @param serverId - ID of the server the credentials belong to.
+     * @returns Credentials for the provided server ID
+     *      or undefined if the store has no server with that ID.
      */
     get(serverId: string): Configuration | undefined {
         if (serverId in this.credentialStore) {
@@ -26,10 +32,9 @@ export class credentialManager {
 
     /**
      * Update credentials for the provided server ID
-     *
-     * @param serverId - ID of the server to update
-     * @param newConfig - Updated Credentials
-     * @returns True if the value was updated, false if it wasn't
+     * @param serverId - ID of the server to update.
+     * @param newConfig - Updated Credentials.
+     * @returns True if the value was updated, false if it wasn't.
      */
     update(serverId: string, newConfig: Configuration): boolean {
         if (serverId in this.credentialStore) {
@@ -43,10 +48,9 @@ export class credentialManager {
 
     /**
      * Add a new credential to store. Only accepts new entries.
-     *
-     * @param serverId - ID of the server the credentials belong to
-     * @param configuration - Credentials of the server
-     * @returns True if server was added, false if it wasn't
+     * @param serverId - ID of the server the credentials belong to.
+     * @param Configuration - Credentials of the server.
+     * @returns True if server was added, false if it wasn't.
      */
     add(serverId: string, configuration: Configuration): boolean {
         if (serverId in this.credentialStore) {
@@ -59,16 +63,14 @@ export class credentialManager {
     }
 
     /**
-     * Add a new credential to store. Only accepts new entries.
-     *
-     * @param serverId - ID of the server the credentials belong to
-     * @returns True if server was added, false if it wasn't
+     * Remove a credential from store.
+     * @param serverId - ID of the server the credentials belong to.
+     * @returns True if server was removed, false if it wasn't.
      */
     remove(serverId: string): boolean {
         if (serverId in this.credentialStore) {
-            delete this.credentialStore[serverId];
-
-            return true;
+            delete this.credentialStore[serverId]
+            return true
         }
 
         return false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
         "paths": {
             "~/*": ["./*"]
         },
-        "types": ["@types/node", "@types/chromecast-caf-receiver"]
+        "types": ["@types/node", "@types/chromecast-caf-receiver", "jest"]
     }
 }


### PR DESCRIPTION
Add constructor to `credentialManager` with optional parameter to initialize the store with.
Add tests for methods in `credentialManager`.
Remove `--passWithNoTests` from test command to disallow passing when no tests are found.