### PR TITLE
WIP: enable mkv and enable passthrough codecs for mkv

### DIFF
--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -216,7 +216,7 @@ export function getSupportedMP4VideoCodecs(): Array<string> {
  * @returns Supported mkv audio codecs.
  */
 export function getSupportedmkvAudioCodecs(): Array<string> {
-    return ['flac', 'aac', 'opus', 'vorbis', 'mp3', 'webma', 'wav'];
+    return ['flac', 'opus', 'aac', 'vorbis', 'mp3', 'webma', 'wav'];
 }
 
 /**
@@ -264,5 +264,5 @@ export function getSupportedWebMAudioCodecs(): Array<string> {
  * @returns All supported WebM audio codecs.
  */
 export function getSupportedAudioCodecs(): Array<string> {
-    return ['opus', 'mp3', 'aac', 'flac', 'webma', 'wav'];
+    return ['flac', 'opus', 'aac', 'mp3', 'webma', 'wav'];
 }

--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -8,13 +8,10 @@ const castContext = cast.framework.CastReceiverContext.getInstance();
  * If the device is in auto, EDID information will be used, otherwise it
  * depends on the manual setting.
  *
- * Currently it's disabled because of problems getting it to work with HLS.
- *
- * @returns true if E-AC-3 can be played
+ * @returns {boolean} true if E-AC-3 can be played
  */
 export function hasEAC3Support(): boolean {
-    //return castContext.canDisplayType('audio/mp4', 'ec-3');
-    return false;
+    return castContext.canDisplayType('audio/mp4', 'ec-3');
 }
 
 /**
@@ -23,29 +20,27 @@ export function hasEAC3Support(): boolean {
  * If the device is in auto, EDID information will be used, otherwise it
  * depends on the manual setting.
  *
- * Currently it's disabled because of problems getting it to work with HLS.
- *
- * @returns true if AC-3 can be played
- *
+ * @returns {boolean} true if AC-3 can be played
  */
 export function hasAC3Support(): boolean {
-    //return castContext.canDisplayType('audio/mp4', 'ac-3');
-    return false;
+    return castContext.canDisplayType('audio/mp4', 'ac-3');
 }
 
 /**
- * Checks if the device can play any surround codecs.
+ * Get a list of the supported surround codecs.
  *
- * Potentially, we could guess that systems with E-AC-3 or AC-3
- * will mostly support 6ch pcm, and if any generation of cast devices
- * is actually capable of decoding e.g. aac 6ch, we can return true here
- * and give it a shot.
- *
- * @returns true if surround codecs can be played
+ * @returns {string[]} list of available surround codecs
  */
-export function hasSurroundSupport(): boolean {
-    // This will turn on surround support if passthrough is available.
-    return hasAC3Support();
+export function getSupportedSurroundCodecs(): string[] {
+    // Note: So far, AC-3 and E-AC-3 in HLS in CAF seems to be broken,
+    const codecs = [];
+    if (hasEAC3Support()) {
+        codecs.push('eac3');
+    }
+    if (hasAC3Support()) {
+        codecs.push('ac3');
+    }
+    return codecs;
 }
 
 /**
@@ -199,20 +194,7 @@ export function getSupportedMP4VideoCodecs(): Array<string> {
  * @returns Supported MP4 audio codecs.
  */
 export function getSupportedMP4AudioCodecs(): Array<string> {
-    const codecs = [];
-
-    if (hasEAC3Support()) {
-        codecs.push('eac3');
-    }
-
-    if (hasAC3Support()) {
-        codecs.push('ac3');
-    }
-
-    codecs.push('aac');
-    codecs.push('mp3');
-
-    return codecs;
+    return ['aac', 'mp3'];
 }
 
 /**

--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -48,7 +48,7 @@ export function getSupportedSurroundCodecs(): string[] {
  *
  * @returns true if HEVC is supported
  */
-export function hasH265Support(): boolean {
+export function hasHEVCSupport(): boolean {
     return castContext.canDisplayType('video/mp4', 'hev1.1.6.L150.B0');
 }
 
@@ -116,38 +116,62 @@ export function getMaxWidthSupport(deviceId: number): number {
 }
 
 /**
- * Get all H.26x profiles supported by the active Cast device.
+ * Get all H.264 profiles supported by the active Cast device.
  *
- * @param deviceId - Cast device id.
- * @returns All supported H.26x profiles.
+ * @returns {string} All supported H.264 profiles.
  */
-export function getH26xProfileSupport(deviceId: number): string {
+export function getH264ProfileSupport(): string {
     // These are supported by all Cast devices, excluding audio only devices.
-    let h26xProfiles = 'high|main|baseline|constrained baseline';
-
-    if (deviceId === deviceIds.ULTRA || deviceId === deviceIds.CCGTV) {
-        h26xProfiles += '|high 10';
-    }
-
-    return h26xProfiles;
+    return 'high|main|baseline|constrained baseline';
 }
 
 /**
- * Get the highest H.26x level supported by the active Cast device.
+ * Get all HEVC profiles supported by the active Cast device.
+ *
+ * @param {number} deviceId Cast device id.
+ * @returns {string} All supported HEVC profiles.
+ */
+export function getHEVCProfileSupport(deviceId: number): string {
+    if (deviceId === deviceIds.ULTRA || deviceId === deviceIds.CCGTV) {
+        return 'main|main 10';
+    } else {
+        // The rest of the cast devices don't support it
+        return '';
+    }
+}
+
+/**
+ * Get the highest H.264 level supported by the active Cast device.
  *
  * @param deviceId - Cast device id.
- * @returns The highest supported H.26x level.
+ * @returns number - The highest supported H.264 level.
  */
-export function getH26xLevelSupport(deviceId: number): number {
+export function getH264LevelSupport(deviceId: number): number {
     switch (deviceId) {
         case deviceIds.NESTHUBANDMAX:
         case deviceIds.GEN1AND2:
             return 41;
         case deviceIds.GEN3:
             return 42;
+        case deviceIds.ULTRA: // docs say 4.2
+        case deviceIds.CCGTV: // docs say 5.1
+            return 52;
+    }
+
+    return 0;
+}
+
+/**
+ * Get the highest HEVC level supported by the active Cast device.
+ *
+ * @param {number} deviceId Cast device id.
+ * @returns {number} The highest supported HEVC level.
+ */
+export function getHEVCLevelSupport(deviceId: number): number {
+    switch (deviceId) {
         case deviceIds.ULTRA:
         case deviceIds.CCGTV:
-            return 52;
+            return 153; // AKA 5.1
     }
 
     return 0;
@@ -180,12 +204,19 @@ export function getSupportedVPXVideoCodecs(): Array<string> {
 export function getSupportedMP4VideoCodecs(): Array<string> {
     const codecs = ['h264'];
 
-    if (hasH265Support()) {
-        codecs.push('h265');
+    if (hasHEVCSupport()) {
         codecs.push('hevc');
     }
 
     return codecs;
+}
+
+/**
+ * Get supported audio codecs suitable for use in an mkv container.
+ * @returns Supported mkv audio codecs.
+ */
+export function getSupportedmkvAudioCodecs(): Array<string> {
+    return ['flac', 'aac', 'opus', 'vorbis', 'mp3', 'webma', 'wav'];
 }
 
 /**
@@ -204,7 +235,7 @@ export function getSupportedMP4AudioCodecs(): Array<string> {
  */
 export function getSupportedHLSVideoCodecs(): Array<string> {
     // Currently the server does not support fmp4 which is required
-    // by the HLS spec for streaming H.265 video.
+    // by the HLS spec for streaming HEVC video.
     return ['h264'];
 }
 

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -72,14 +72,7 @@ function getContainerProfiles(): Array<ContainerProfile> {
  * @returns Response profiles.
  */
 function getResponseProfiles(): Array<ResponseProfile> {
-    // This seems related to DLNA, it might not be needed?
-    return [
-        {
-            Container: 'm4v',
-            MimeType: 'video/mp4',
-            Type: DlnaProfileType.Video
-        }
-    ];
+    return [];
 }
 
 /**

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -185,24 +185,26 @@ function getCodecProfiles(): Array<CodecProfile> {
         return CodecProfiles;
     }
 
-    // TODO do this for other codecs as well.
-    CodecProfiles.push({
-        Codec: 'aac',
-        Conditions: [
-            // Not sure what secondary audio means in this context. Multiple audio tracks?
-            createProfileCondition(
-                ProfileConditionValue.IsSecondaryAudio,
-                ProfileConditionType.Equals,
-                'false'
-            ),
-            createProfileCondition(
-                ProfileConditionValue.IsSecondaryAudio,
-                ProfileConditionType.LessThanEqual,
-                '2'
-            )
-        ],
-        Type: CodecType.VideoAudio
-    });
+    for (const acodec in getSupportedmkvAudioCodecs()) {
+        CodecProfiles.push({
+            Codec: acodec,
+            Conditions: [
+                // This condition says that the codec is not supported as an additional audio track,
+                // telling the server to only send one audio track.
+                createProfileCondition(
+                    ProfileConditionValue.IsSecondaryAudio,
+                    ProfileConditionType.Equals,
+                    'false'
+                ),
+                createProfileCondition(
+                    ProfileConditionValue.IsSecondaryAudio,
+                    ProfileConditionType.LessThanEqual,
+                    '2'
+                )
+            ],
+            Type: CodecType.VideoAudio
+        });
+    }
 
     const maxWidth: number = getMaxWidthSupport(currentDeviceId);
 

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -430,10 +430,7 @@ export function getDeviceProfile(options: ProfileOptions): DeviceProfile {
     const profile: DeviceProfile = {
         MaxStaticBitrate: options.bitrateSetting,
         MaxStreamingBitrate: options.bitrateSetting,
-        MusicStreamingTranscodingBitrate: Math.min(
-            options.bitrateSetting,
-            192000
-        )
+        MusicStreamingTranscodingBitrate: options.bitrateSetting
     };
 
     profile.DirectPlayProfiles = getDirectPlayProfiles();

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -805,7 +805,14 @@ export function createMediaInformation(
     console.log('streamInfo', streamInfo);
     const mediaInfo = new cast.framework.messages.MediaInformation();
 
-    mediaInfo.contentId = streamInfo.url;
+    if (streamInfo.contentType == 'application/x-mpegURL') {
+        // assume normal TS HLS
+        mediaInfo.hlsSegmentFormat =
+            cast.framework.messages.HlsSegmentFormat.TS;
+    }
+
+    mediaInfo.contentId = item.Id ?? streamInfo.url;
+    mediaInfo.contentUrl = streamInfo.url;
     mediaInfo.contentType = streamInfo.contentType;
     mediaInfo.customData = {
         audioStreamIndex: streamInfo.audioStreamIndex,

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -802,6 +802,7 @@ export function createMediaInformation(
     item: BaseItemDto,
     streamInfo: any
 ): framework.messages.MediaInformation {
+    console.log('streamInfo', streamInfo);
     const mediaInfo = new cast.framework.messages.MediaInformation();
 
     mediaInfo.contentId = streamInfo.url;

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -214,6 +214,7 @@ export class playbackManager {
         loadRequestData.autoplay = true;
 
         load($scope, mediaInfo.customData, item);
+        console.log('loading media:', loadRequestData);
         this.playerManager.load(loadRequestData);
 
         $scope.PlaybackMediaSource = mediaSource;


### PR DESCRIPTION
This enables mkv. This is not ideal because chromecast does not officially support mkv and there are edge cases where chromecast will choke on some of these mkv files.

However, this is how it works on chromecast stable, it enables AC3 and EAC3 to work and it doesn't suffer from the performance issues that I have seen while trying to play HLS.

This should be seen as buying time to get HLS/fmp4 or an alternative that is actually supported working.

EDIT: this branch works with eac3+h264 on gen2+gen3 at least.
Please test this a lot :)