### PR TITLE
Fix bitrate check

### DIFF
--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -561,7 +561,7 @@ export function getMaxBitrate(): Promise<number> {
                 lastBitrateDetect = new Date().getTime();
                 detectedBitrate = bitrate;
 
-                resolve(detectedBitrate);
+                resolve(Math.min(detectedBitrate, getMaxBitrateSupport()));
             },
             () => {
                 console.log(


### PR DESCRIPTION
Turns out the device overestimates the bitrate. The bitrate promise gets resolved before the actual content has been transferred.

I also took the liberty to try improving the algorithm, initially starting at half of the current size.

Finally, the detected bitrate needs to be cappable by the device maximum function, not just as a fallback.