### PR TITLE
Misc fixes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,4 @@ import './css/jellyfin.css';
 
 window.mediaElement = document.getElementById('video-player');
 
-window.playlist = [];
-window.currentPlaylistIndex = -1;
 window.repeatMode = RepeatMode.RepeatNone;

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,18 +3,6 @@ import './components/maincontroller';
 import './css/glyphicons.css';
 import './css/jellyfin.css';
 
-const senders = cast.framework.CastReceiverContext.getInstance().getSenders();
-const id =
-    senders.length !== 0 && senders[0].id
-        ? senders[0].id
-        : new Date().getTime();
-
-window.deviceInfo = {
-    deviceId: id,
-    deviceName: 'Google Cast',
-    versionNumber: RECEIVERVERSION
-};
-
 window.mediaElement = document.getElementById('video-player');
 
 window.playlist = [];

--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -102,22 +102,28 @@ export function getMaxBitrateSupport(): number {
 /**
  * Get the max supported video width the active Cast device supports.
  *
- * @param deviceId - Cast device id.
  * @returns Max supported width.
  */
-export function getMaxWidthSupport(deviceId: number): number {
-    switch (deviceId) {
-        case deviceIds.ULTRA:
-        case deviceIds.CCGTV:
-            return 3840;
-        case deviceIds.GEN1AND2:
-        case deviceIds.GEN3:
-            return 1920;
-        case deviceIds.NESTHUBANDMAX:
-            return 1280;
-    }
+export function getMaxWidthSupport(): number {
+    // with HLS, it will produce a manifest error if we
+    // send any stream larger than the screen size...
+    return window.innerWidth;
 
-    return 0;
+    // mkv playback can use the device limitations.
+    // The devices are capable of decoding and downscaling,
+    // they just refuse to do it with HLS. This increases
+    // the rate of direct playback.
+    //switch (deviceId) {
+    //    case deviceIds.ULTRA:
+    //    case deviceIds.CCGTV:
+    //        return 3840;
+    //    case deviceIds.GEN1AND2:
+    //    case deviceIds.GEN3:
+    //        return 1920;
+    //    case deviceIds.NESTHUBANDMAX:
+    //        return 1280;
+    //}
+    //return 0;
 }
 
 /**

--- a/src/components/commandHandler.ts
+++ b/src/components/commandHandler.ts
@@ -131,6 +131,7 @@ export abstract class CommandHandler {
 
     static IdentifyHandler(): void {
         if (!PlaybackManager.isPlaying()) {
+            DocumentManager.setAppStatus('waiting');
             DocumentManager.startBackdropInterval();
         } else {
             // When a client connects send back the initial device state (volume etc) via a playbackstop message

--- a/src/components/commandHandler.ts
+++ b/src/components/commandHandler.ts
@@ -19,13 +19,12 @@ import {
 
 import { reportPlaybackProgress } from './jellyfinActions';
 
-import { playbackManager } from './playbackManager';
+import { PlaybackManager } from './playbackManager';
 
 import { DocumentManager } from './documentManager';
 
 export abstract class CommandHandler {
     private static playerManager: framework.PlayerManager;
-    private static playbackManager: playbackManager;
     private static supportedCommands: SupportedCommands = {
         DisplayContent: CommandHandler.displayContentHandler,
         Identify: CommandHandler.IdentifyHandler,
@@ -52,12 +51,8 @@ export abstract class CommandHandler {
         VolumeUp: CommandHandler.VolumeUpHandler
     };
 
-    static configure(
-        playerManager: framework.PlayerManager,
-        playbackManager: playbackManager
-    ): void {
+    static configure(playerManager: framework.PlayerManager): void {
         this.playerManager = playerManager;
-        this.playbackManager = playbackManager;
     }
 
     static playNextHandler(data: DataMessage): void {
@@ -89,23 +84,20 @@ export abstract class CommandHandler {
     }
 
     static displayContentHandler(data: DataMessage): void {
-        if (!this.playbackManager.isPlaying()) {
+        if (!PlaybackManager.isPlaying()) {
             DocumentManager.showItemId((<DisplayRequest>data.options).ItemId);
         }
     }
 
     static nextTrackHandler(): void {
-        if (
-            window.playlist &&
-            window.currentPlaylistIndex < window.playlist.length - 1
-        ) {
-            this.playbackManager.playNextItem({}, true);
+        if (PlaybackManager.hasNextItem()) {
+            PlaybackManager.playNextItem({}, true);
         }
     }
 
     static previousTrackHandler(): void {
-        if (window.playlist && window.currentPlaylistIndex > 0) {
-            this.playbackManager.playPreviousItem({});
+        if (PlaybackManager.hasPrevItem()) {
+            PlaybackManager.playPreviousItem({});
         }
     }
 
@@ -138,7 +130,7 @@ export abstract class CommandHandler {
     }
 
     static IdentifyHandler(): void {
-        if (!this.playbackManager.isPlaying()) {
+        if (!PlaybackManager.isPlaying()) {
             DocumentManager.startBackdropInterval();
         } else {
             // When a client connects send back the initial device state (volume etc) via a playbackstop message

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -195,7 +195,7 @@ function getCodecProfiles(): Array<CodecProfile> {
 
     CodecProfiles.push(aacConditions);
 
-    const maxWidth: number = getMaxWidthSupport(currentDeviceId);
+    const maxWidth: number = getMaxWidthSupport();
     const h26xLevel: number = getH26xLevelSupport(currentDeviceId);
     const h26xProfile: string = getH26xProfileSupport(currentDeviceId);
 

--- a/src/components/jellyfinActions.ts
+++ b/src/components/jellyfinActions.ts
@@ -251,15 +251,6 @@ export function play($scope: GlobalScope): void {
 }
 
 /**
- * Don't actually stop, just show the idle view after 20ms
- */
-export function stop(): void {
-    setTimeout(() => {
-        DocumentManager.setAppStatus('waiting');
-    }, 20);
-}
-
-/**
  * @param item
  * @param maxBitrate
  * @param deviceProfile

--- a/src/components/jellyfinActions.ts
+++ b/src/components/jellyfinActions.ts
@@ -409,7 +409,7 @@ export async function detectBitrate(): Promise<number> {
  */
 export function stopActiveEncodings($scope: GlobalScope): Promise<void> {
     const options = {
-        deviceId: window.deviceInfo.deviceId,
+        deviceId: JellyfinApi.deviceId,
         PlaySessionId: undefined
     };
 

--- a/src/components/jellyfinActions.ts
+++ b/src/components/jellyfinActions.ts
@@ -230,7 +230,7 @@ export function play($scope: GlobalScope): void {
         DocumentManager.getAppStatus() == 'audio'
     ) {
         setTimeout(() => {
-            window.mediaManager.play();
+            window.playerManager.play();
 
             if ($scope.mediaType == 'Audio') {
                 DocumentManager.setAppStatus('audio');

--- a/src/components/jellyfinActions.ts
+++ b/src/components/jellyfinActions.ts
@@ -1,7 +1,6 @@
 import {
     getSenderReportingData,
     resetPlaybackScope,
-    extend,
     broadcastToMessageBus
 } from '../helpers';
 
@@ -199,12 +198,22 @@ export function pingTranscoder(
  */
 export function load(
     $scope: GlobalScope,
-    customData: PlaybackProgressInfo,
+    customData: any,
     serverItem: BaseItemDto
 ): void {
     resetPlaybackScope($scope);
 
-    extend($scope, customData);
+    // These are set up in maincontroller.createMediaInformation
+    $scope.playSessionId = customData.playSessionId;
+    $scope.audioStreamIndex = customData.audioStreamIndex;
+    $scope.subtitleStreamIndex = customData.subtitleStreamIndex;
+    $scope.startPositionTicks = customData.startPositionTicks;
+    $scope.canSeek = customData.canSeek;
+    $scope.itemId = customData.itemId;
+    $scope.liveStreamId = customData.liveStreamId;
+    $scope.mediaSourceId = customData.mediaSourceId;
+    $scope.playMethod = customData.playMethod;
+    $scope.runtimeTicks = customData.runtimeTicks;
 
     $scope.item = serverItem;
 

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -12,6 +12,7 @@ import {
     broadcastConnectionErrorMessage
 } from '../helpers';
 import {
+    reportPlaybackStart,
     reportPlaybackProgress,
     reportPlaybackStopped,
     play,
@@ -154,7 +155,6 @@ window.playerManager.addEventListener(
     cast.framework.events.EventType.PLAY,
     (): void => {
         play($scope);
-        reportPlaybackProgress($scope, getReportingParams($scope));
     }
 );
 
@@ -197,6 +197,21 @@ window.playerManager.addEventListener(
             window.currentPlaylistIndex = -1;
             DocumentManager.startBackdropInterval();
         }
+    }
+);
+
+// Notify of playback start as soon as the media is playing. Only then is the tick position good.
+window.playerManager.addEventListener(
+    cast.framework.events.EventType.PLAYING,
+    (): void => {
+        reportPlaybackStart($scope, getReportingParams($scope));
+    }
+);
+// Notify of playback end just before stopping it, to get a good tick position
+window.playerManager.addEventListener(
+    cast.framework.events.EventType.REQUEST_STOP,
+    (): void => {
+        reportPlaybackStopped($scope, getReportingParams($scope));
     }
 );
 

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -613,7 +613,7 @@ export async function getMaxBitrate(): Promise<number> {
         lastBitrateDetect = new Date().getTime();
         detectedBitrate = bitrate;
 
-        return detectedBitrate;
+        return Math.min(detectedBitrate, getMaxBitrateSupport());
     } catch (e) {
         // The client can set this number
         console.log('Error detecting bitrate, will return device maximum.');

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -165,17 +165,17 @@ window.playerManager.addEventListener(
 /**
  *
  */
-function defaultOnStop(): void {
-    playbackMgr.stop();
+function defaultOnStopped(): void {
+    playbackMgr.onStopped(true);
 }
 
 window.playerManager.addEventListener(
     cast.framework.events.EventType.MEDIA_FINISHED,
-    defaultOnStop
+    defaultOnStopped
 );
 window.playerManager.addEventListener(
     cast.framework.events.EventType.ABORT,
-    defaultOnStop
+    defaultOnStopped
 );
 
 window.playerManager.addEventListener(

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -590,11 +590,8 @@ export async function shuffle(
 }
 
 /**
- * This function fetches the full information for an item before playing it.
- * The provided item is not complete.
- *
- * Old behavior: The original properties would be copied over to the fetched one,
- * but just the fetched item should be fine
+ * This function fetches the full information of an item before playing it.
+ * Only item.Id needs to be set.
  *
  * @param item - Item to look up
  * @param options - Extra information about how it should be played back.
@@ -837,7 +834,9 @@ export function createMediaInformation(
         );
     }
 
-    mediaInfo.customData.startPositionTicks = streamInfo.startPosition || 0;
+    // If the client actually sets startPosition:
+    // if(streamInfo.startPosition)
+    //     mediaInfo.customData.startPositionTicks = streamInfo.startPosition
 
     return mediaInfo;
 }

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -8,7 +8,6 @@ import {
     getShuffleItems,
     getInstantMixItems,
     translateRequestedItems,
-    extend,
     broadcastToMessageBus,
     broadcastConnectionErrorMessage
 } from '../helpers';
@@ -591,8 +590,15 @@ export async function shuffle(
 }
 
 /**
- * @param item
- * @param options
+ * This function fetches the full information for an item before playing it.
+ * The provided item is not complete.
+ *
+ * Old behavior: The original properties would be copied over to the fetched one,
+ * but just the fetched item should be fine
+ *
+ * @param item - Item to look up
+ * @param options - Extra information about how it should be played back.
+ * @returns Promise waiting for the item to be loaded for playback
  */
 export async function onStopPlayerBeforePlaybackDone(
     item: BaseItemDto,
@@ -603,8 +609,6 @@ export async function onStopPlayerBeforePlaybackDone(
         type: 'GET'
     });
 
-    // Attach the custom properties we created like userId, serverAddress, itemId, etc
-    extend(data, item);
     playbackMgr.playItemInternal(data, options);
     broadcastConnectionErrorMessage();
 }
@@ -807,6 +811,7 @@ export function createMediaInformation(
 
     mediaInfo.contentId = streamInfo.url;
     mediaInfo.contentType = streamInfo.contentType;
+    // TODO make a type for this
     mediaInfo.customData = {
         audioStreamIndex: streamInfo.audioStreamIndex,
         canClientSeek: streamInfo.canClientSeek,

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -10,8 +10,7 @@ import {
     translateRequestedItems,
     extend,
     broadcastToMessageBus,
-    broadcastConnectionErrorMessage,
-    cleanName
+    broadcastConnectionErrorMessage
 } from '../helpers';
 import {
     reportPlaybackProgress,
@@ -261,36 +260,28 @@ export function processMessage(data: any): void {
         return;
     }
 
+    data.options = data.options || {};
+
     // Items will have properties - Id, Name, Type, MediaType, IsFolder
 
     JellyfinApi.setServerInfo(
         data.userId,
         data.accessToken,
-        data.serverAddress
+        data.serverAddress,
+        data.receiverName || ''
     );
 
     if (data.subtitleAppearance) {
         window.subtitleAppearance = data.subtitleAppearance;
     }
 
+    if (data.maxBitrate) {
+        window.MaxBitrate = data.maxBitrate;
+    }
+
     // Report device capabilities
     if (!hasReportedCapabilities) {
         reportDeviceCapabilities();
-    }
-
-    data.options = data.options || {};
-
-    const cleanReceiverName = cleanName(data.receiverName || '');
-
-    window.deviceInfo.deviceName =
-        cleanReceiverName || window.deviceInfo.deviceName;
-    // deviceId just needs to be unique-ish
-    window.deviceInfo.deviceId = cleanReceiverName
-        ? btoa(cleanReceiverName)
-        : window.deviceInfo.deviceId;
-
-    if (data.maxBitrate) {
-        window.MaxBitrate = data.maxBitrate;
     }
 
     CommandHandler.processMessage(data, data.command);

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -140,7 +140,8 @@ export class playbackManager {
             options.startPositionTicks,
             options.mediaSourceId,
             options.audioStreamIndex,
-            options.subtitleStreamIndex
+            options.subtitleStreamIndex,
+            options.liveStreamId
         ).catch(broadcastConnectionErrorMessage);
 
         if (playbackInfo.ErrorCode) {
@@ -198,8 +199,6 @@ export class playbackManager {
             options.startPositionTicks
         );
 
-        const url = streamInfo.url;
-
         const mediaInfo = createMediaInformation(
             playSessionId,
             item,
@@ -220,10 +219,12 @@ export class playbackManager {
         load($scope, mediaInfo.customData, item);
         this.playerManager.load(loadRequestData);
 
+        console.log(`setting src to ${streamInfo.url}`);
         $scope.PlaybackMediaSource = mediaSource;
 
-        console.log(`setting src to ${url}`);
         $scope.mediaSource = mediaSource;
+        $scope.audioStreamIndex = streamInfo.audioStreamIndex;
+        $scope.subtitleStreamIndex = streamInfo.subtitleStreamIndex;
 
         DocumentManager.setPlayerBackdrop(item);
 

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -213,6 +213,13 @@ export class playbackManager {
         loadRequestData.media = mediaInfo;
         loadRequestData.autoplay = true;
 
+        // If we should seek at the start, translate it
+        // to seconds and give it to loadRequestData :)
+        if (mediaInfo.customData.startPositionTicks > 0) {
+            loadRequestData.currentTime =
+                mediaInfo.customData.startPositionTicks / 10000000;
+        }
+
         load($scope, mediaInfo.customData, item);
         this.playerManager.load(loadRequestData);
 

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -2,7 +2,6 @@ import {
     getNextPlaybackItemInfo,
     getIntros,
     broadcastConnectionErrorMessage,
-    getReportingParams,
     createStreamInfo
 } from '../helpers';
 
@@ -10,10 +9,8 @@ import {
     getPlaybackInfo,
     getLiveStream,
     load,
-    reportPlaybackStart,
     stop,
-    stopPingInterval,
-    reportPlaybackStopped
+    stopPingInterval
 } from './jellyfinActions';
 import { getDeviceProfile } from './deviceprofileBuilder';
 
@@ -230,36 +227,22 @@ export class playbackManager {
 
         DocumentManager.setPlayerBackdrop(item);
 
-        reportPlaybackStart($scope, getReportingParams($scope));
-
         // We use false as we do not want to broadcast the new status yet
         // we will broadcast manually when the media has been loaded, this
         // is to be sure the duration has been updated in the media element
         this.playerManager.setMediaInformation(mediaInfo, false);
     }
 
-    stop(continuing = false): Promise<any> {
+    stop(continuing = false): void {
         $scope.playNextItem = continuing;
         stop();
 
-        const reportingParams = getReportingParams($scope);
-
-        let promise;
-
         stopPingInterval();
-
-        if (reportingParams.ItemId) {
-            promise = reportPlaybackStopped($scope, reportingParams);
-        }
 
         this.playerManager.stop();
 
         this.activePlaylist = [];
         this.activePlaylistIndex = -1;
         DocumentManager.startBackdropInterval();
-
-        promise = promise || Promise.resolve();
-
-        return promise;
     }
 }

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -1,5 +1,4 @@
 import {
-    getNextPlaybackItemInfo,
     getIntros,
     broadcastConnectionErrorMessage,
     createStreamInfo
@@ -26,19 +25,18 @@ import { DocumentManager } from './documentManager';
 import { BaseItemDto } from '~/api/generated/models/base-item-dto';
 import { MediaSourceInfo } from '~/api/generated/models/media-source-info';
 
-export class playbackManager {
-    private playerManager: framework.PlayerManager;
-    // TODO remove any
-    private activePlaylist: Array<BaseItemDto>;
-    private activePlaylistIndex: number;
+import { ItemIndex } from '~/types/global';
 
-    constructor(playerManager: framework.PlayerManager) {
+export abstract class PlaybackManager {
+    private static playerManager: framework.PlayerManager;
+    private static activePlaylist: Array<BaseItemDto>;
+    private static activePlaylistIndex: number;
+
+    static setPlayerManager(playerManager: framework.PlayerManager): void {
         // Parameters
         this.playerManager = playerManager;
 
-        // Properties
-        this.activePlaylist = [];
-        this.activePlaylistIndex = 0;
+        this.resetPlaylist();
     }
 
     /* This is used to check if we can switch to
@@ -47,7 +45,7 @@ export class playbackManager {
      * Returns true when playing or paused.
      * (before: true only when playing)
      * */
-    isPlaying(): boolean {
+    static isPlaying(): boolean {
         return (
             this.playerManager.getPlayerState() ===
                 cast.framework.messages.PlayerState.PLAYING ||
@@ -56,7 +54,7 @@ export class playbackManager {
         );
     }
 
-    async playFromOptions(options: any): Promise<boolean> {
+    static async playFromOptions(options: any): Promise<boolean> {
         const firstItem = options.items[0];
 
         if (options.startPositionTicks || firstItem.MediaType !== 'Video') {
@@ -70,26 +68,46 @@ export class playbackManager {
         return this.playFromOptionsInternal(options);
     }
 
-    playFromOptionsInternal(options: any): boolean {
+    private static playFromOptionsInternal(options: any): boolean {
         const stopPlayer =
             this.activePlaylist && this.activePlaylist.length > 0;
 
         this.activePlaylist = options.items;
-        window.currentPlaylistIndex = -1;
-        window.playlist = this.activePlaylist;
+        // We need to set -1 so the next index will be 0
+        this.activePlaylistIndex = -1;
+
+        console.log('Loaded new playlist:', this.activePlaylist);
 
         return this.playNextItem(options, stopPlayer);
     }
 
-    playNextItem(options: any = {}, stopPlayer = false): boolean {
-        const nextItemInfo = getNextPlaybackItemInfo();
+    // add item to playlist
+    static enqueue(item: BaseItemDto): void {
+        this.activePlaylist.push(item);
+    }
+
+    static resetPlaylist(): void {
+        this.activePlaylistIndex = -1;
+        this.activePlaylist = [];
+    }
+
+    // If there are items in the queue after the current one
+    static hasNextItem(): boolean {
+        return this.activePlaylistIndex < this.activePlaylist.length - 1;
+    }
+
+    // If there are items in the queue before the current one
+    static hasPrevItem(): boolean {
+        return this.activePlaylistIndex > 0;
+    }
+
+    static playNextItem(options: any = {}, stopPlayer = false): boolean {
+        const nextItemInfo = this.getNextPlaybackItemInfo();
 
         if (nextItemInfo) {
             this.activePlaylistIndex = nextItemInfo.index;
 
-            const item = nextItemInfo.item;
-
-            this.playItem(item, options, stopPlayer);
+            this.playItem(options, stopPlayer);
 
             return true;
         }
@@ -97,13 +115,11 @@ export class playbackManager {
         return false;
     }
 
-    playPreviousItem(options: any = {}): boolean {
+    static playPreviousItem(options: any = {}): boolean {
         if (this.activePlaylist && this.activePlaylistIndex > 0) {
             this.activePlaylistIndex--;
 
-            const item = this.activePlaylist[this.activePlaylistIndex];
-
-            this.playItem(item, options, true);
+            this.playItem(options, true);
 
             return true;
         }
@@ -111,8 +127,8 @@ export class playbackManager {
         return false;
     }
 
-    async playItem(
-        item: BaseItemDto,
+    // play item from playlist
+    private static async playItem(
         options: any,
         stopPlayer = false
     ): Promise<void> {
@@ -120,10 +136,18 @@ export class playbackManager {
             this.stop();
         }
 
+        const item = this.activePlaylist[this.activePlaylistIndex];
+
+        console.log(`Playing index ${this.activePlaylistIndex}`, item);
+
         return await onStopPlayerBeforePlaybackDone(item, options);
     }
 
-    async playItemInternal(item: BaseItemDto, options: any): Promise<void> {
+    // Would set private, but some refactorings need to happen first.
+    static async playItemInternal(
+        item: BaseItemDto,
+        options: any
+    ): Promise<void> {
         $scope.isChangingStream = false;
         DocumentManager.setAppStatus('loading');
 
@@ -183,8 +207,7 @@ export class playbackManager {
         );
     }
 
-    // TODO eradicate any
-    playMediaSource(
+    private static playMediaSource(
         playSessionId: string,
         item: BaseItemDto,
         mediaSource: MediaSourceInfo,
@@ -236,7 +259,7 @@ export class playbackManager {
     /**
      * stop playback, as requested by the client
      */
-    stop(): void {
+    static stop(): void {
         this.playerManager.stop();
         // onStopped will be called when playback comes to a halt.
     }
@@ -244,18 +267,62 @@ export class playbackManager {
     /**
      * Called when media stops playing.
      * TODO avoid doing this between tracks in a playlist
-     *
-     * @param _continue - If we have another item coming up in the playlist. Only used for notifying the cast sender.
      */
-    onStopped(_continue: boolean): void {
-        $scope.playNextItem = _continue;
+    static onStopped(): void {
+        if (this.getNextPlaybackItemInfo()) {
+            $scope.playNextItem = true;
+        } else {
+            $scope.playNextItem = false;
 
-        DocumentManager.setAppStatus('waiting');
+            DocumentManager.setAppStatus('waiting');
 
-        stopPingInterval();
+            stopPingInterval();
 
-        this.activePlaylist = [];
-        this.activePlaylistIndex = -1;
-        DocumentManager.startBackdropInterval();
+            DocumentManager.startBackdropInterval();
+        }
+    }
+
+    /**
+     * Get information about the next item to play from window.playlist
+     *
+     * @returns item and index, or null to end playback
+     */
+    static getNextPlaybackItemInfo(): ItemIndex | null {
+        if (this.activePlaylist.length < 1) {
+            return null;
+        }
+
+        let newIndex: number;
+
+        if (this.activePlaylistIndex < 0) {
+            // negative = play the first item
+            newIndex = 0;
+        } else {
+            switch (window.repeatMode) {
+                case 'RepeatOne':
+                    newIndex = this.activePlaylistIndex;
+                    break;
+                case 'RepeatAll':
+                    newIndex = this.activePlaylistIndex + 1;
+
+                    if (newIndex >= this.activePlaylist.length) {
+                        newIndex = 0;
+                    }
+
+                    break;
+                default:
+                    newIndex = this.activePlaylistIndex + 1;
+                    break;
+            }
+        }
+
+        if (newIndex < this.activePlaylist.length) {
+            return {
+                index: newIndex,
+                item: this.activePlaylist[newIndex]
+            };
+        }
+
+        return null;
     }
 }

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -9,7 +9,6 @@ import {
     getPlaybackInfo,
     getLiveStream,
     load,
-    stop,
     stopPingInterval
 } from './jellyfinActions';
 import { getDeviceProfile } from './deviceprofileBuilder';
@@ -118,7 +117,7 @@ export class playbackManager {
         stopPlayer = false
     ): Promise<void> {
         if (stopPlayer) {
-            await this.stop(true);
+            this.stop();
         }
 
         return await onStopPlayerBeforePlaybackDone(item, options);
@@ -234,13 +233,26 @@ export class playbackManager {
         this.playerManager.setMediaInformation(mediaInfo, false);
     }
 
-    stop(continuing = false): void {
-        $scope.playNextItem = continuing;
-        stop();
+    /**
+     * stop playback, as requested by the client
+     */
+    stop(): void {
+        this.playerManager.stop();
+        // onStopped will be called when playback comes to a halt.
+    }
+
+    /**
+     * Called when media stops playing.
+     * TODO avoid doing this between tracks in a playlist
+     *
+     * @param _continue - If we have another item coming up in the playlist. Only used for notifying the cast sender.
+     */
+    onStopped(_continue: boolean): void {
+        $scope.playNextItem = _continue;
+
+        DocumentManager.setAppStatus('waiting');
 
         stopPingInterval();
-
-        this.playerManager.stop();
 
         this.activePlaylist = [];
         this.activePlaylistIndex = -1;

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -54,7 +54,7 @@ export abstract class PlaybackManager {
         );
     }
 
-    static async playFromOptions(options: any): Promise<boolean> {
+    static async playFromOptions(options: any): Promise<void> {
         const firstItem = options.items[0];
 
         if (options.startPositionTicks || firstItem.MediaType !== 'Video') {
@@ -68,17 +68,18 @@ export abstract class PlaybackManager {
         return this.playFromOptionsInternal(options);
     }
 
-    private static playFromOptionsInternal(options: any): boolean {
+    private static playFromOptionsInternal(options: any): Promise<void> {
         const stopPlayer =
             this.activePlaylist && this.activePlaylist.length > 0;
 
         this.activePlaylist = options.items;
-        // We need to set -1 so the next index will be 0
-        this.activePlaylistIndex = -1;
+        this.activePlaylistIndex = options.startIndex || 0;
 
         console.log('Loaded new playlist:', this.activePlaylist);
 
-        return this.playNextItem(options, stopPlayer);
+        // When starting playback initially, don't use
+        // the next item facility.
+        return this.playItem(options, stopPlayer);
     }
 
     // add item to playlist

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,6 @@
 import { JellyfinApi } from './components/jellyfinApi';
 import { DocumentManager } from './components/documentManager';
+import { PlaybackManager } from './components/playbackManager';
 
 import { BaseItemDtoQueryResult } from './api/generated/models/base-item-dto-query-result';
 import { PlaybackProgressInfo } from './api/generated/models/playback-progress-info';
@@ -7,7 +8,7 @@ import { MediaSourceInfo } from './api/generated/models/media-source-info';
 import { BaseItemDto } from './api/generated/models/base-item-dto';
 import { BaseItemPerson } from './api/generated/models/base-item-person';
 import { UserDto } from './api/generated/models/user-dto';
-import { GlobalScope, BusMessage, ItemIndex, ItemQuery } from './types/global';
+import { GlobalScope, BusMessage, ItemQuery } from './types/global';
 
 /**
  * Get current playback position in ticks, adjusted for server seeking
@@ -55,53 +56,6 @@ export function getReportingParams($scope: GlobalScope): PlaybackProgressInfo {
         SubtitleStreamIndex: $scope.subtitleStreamIndex,
         VolumeLevel: Math.round(window.volume.level * 100)
     };
-}
-
-/**
- * Get information about the next item to play from window.playlist
- *
- * @returns ItemIndex including item and index, or null to end playback
- */
-export function getNextPlaybackItemInfo(): ItemIndex | null {
-    const playlist = window.playlist;
-
-    if (!playlist) {
-        return null;
-    }
-
-    let newIndex: number;
-
-    if (window.currentPlaylistIndex == -1) {
-        newIndex = 0;
-    } else {
-        switch (window.repeatMode) {
-            case 'RepeatOne':
-                newIndex = window.currentPlaylistIndex;
-                break;
-            case 'RepeatAll':
-                newIndex = window.currentPlaylistIndex + 1;
-
-                if (newIndex >= window.playlist.length) {
-                    newIndex = 0;
-                }
-
-                break;
-            default:
-                newIndex = window.currentPlaylistIndex + 1;
-                break;
-        }
-    }
-
-    if (newIndex < playlist.length) {
-        const item = playlist[newIndex];
-
-        return {
-            index: newIndex,
-            item: item
-        };
-    }
-
-    return null;
 }
 
 /**
@@ -196,7 +150,7 @@ export function getSenderReportingData(
         }
 
         if ($scope.playNextItem) {
-            const nextItemInfo = getNextPlaybackItemInfo();
+            const nextItemInfo = PlaybackManager.getNextPlaybackItemInfo();
 
             if (nextItemInfo) {
                 state.NextMediaType = nextItemInfo.item.MediaType;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -859,13 +859,3 @@ export function broadcastToMessageBus(message: BusMessage): void {
 export function broadcastConnectionErrorMessage(): void {
     broadcastToMessageBus({ message: '', type: 'connectionerror' });
 }
-
-/**
- * Remove all special characters from a string
- *
- * @param name - input string
- * @returns string with non-whitespace non-word characters removed
- */
-export function cleanName(name: string): string {
-    return name.replace(/[^\w\s]/gi, '');
-}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -228,7 +228,6 @@ export function resetPlaybackScope($scope: GlobalScope): void {
 
     $scope.playMethod = '';
     $scope.canSeek = false;
-    $scope.canClientSeek = false;
     $scope.isChangingStream = false;
     $scope.playNextItem = true;
 
@@ -809,23 +808,6 @@ export async function translateRequestedItems(
     return {
         Items: items
     };
-}
-
-/**
- * Take all properties of source and copy them over to target
- *
- * TODO can we remove this crap
- *
- * @param target - object that gets populated with entries
- * @param source - object that the entries are copied from
- * @returns reference to target object
- */
-export function extend(target: any, source: any): any {
-    for (const i in source) {
-        target[i] = source[i];
-    }
-
-    return target;
 }
 
 /**

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -16,8 +16,8 @@ import { GlobalScope, BusMessage, ItemIndex, ItemQuery } from './types/global';
  * @returns position in ticks
  */
 export function getCurrentPositionTicks($scope: GlobalScope): number {
-    let positionTicks = window.mediaManager.getCurrentTimeSec() * 10000000;
-    const mediaInformation = window.mediaManager.getMediaInformation();
+    let positionTicks = window.playerManager.getCurrentTimeSec() * 10000000;
+    const mediaInformation = window.playerManager.getMediaInformation();
 
     if (mediaInformation && !mediaInformation.customData.canClientSeek) {
         positionTicks += $scope.startPositionTicks || 0;
@@ -43,7 +43,7 @@ export function getReportingParams($scope: GlobalScope): PlaybackProgressInfo {
         CanSeek: $scope.canSeek,
         IsMuted: window.volume.muted,
         IsPaused:
-            window.mediaManager.getPlayerState() ===
+            window.playerManager.getPlayerState() ===
             cast.framework.messages.PlayerState.PAUSED,
         ItemId: $scope.itemId,
         LiveStreamId: $scope.liveStreamId,

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -99,8 +99,6 @@ declare global {
         mediaElement: HTMLElement | null;
         playerManager: PlayerManager;
         castReceiverContext: CastReceiverContext;
-        playlist: Array<any>;
-        currentPlaylistIndex: number;
         repeatMode: RepeatMode;
         reportEventType: 'repeatmodechange';
         subtitleAppearance: any;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -6,12 +6,6 @@ import { SystemVolumeData } from 'chromecast-caf-receiver/cast.framework.system'
 import { RepeatMode } from '../api/generated/models/repeat-mode';
 import { BaseItemDto } from '../api/generated/models/base-item-dto';
 
-export interface DeviceInfo {
-    deviceId: string | number;
-    deviceName: string;
-    versionNumber: string;
-}
-
 export interface GlobalScope {
     [key: string]: any;
 }
@@ -102,7 +96,6 @@ declare global {
     export const RECEIVERVERSION: string;
     export const $scope: GlobalScope;
     export interface Window {
-        deviceInfo: DeviceInfo;
         mediaElement: HTMLElement | null;
         playerManager: PlayerManager;
         castReceiverContext: CastReceiverContext;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -104,7 +104,7 @@ declare global {
     export interface Window {
         deviceInfo: DeviceInfo;
         mediaElement: HTMLElement | null;
-        mediaManager: PlayerManager;
+        playerManager: PlayerManager;
         castReceiverContext: CastReceiverContext;
         playlist: Array<any>;
         currentPlaylistIndex: number;


### PR DESCRIPTION
Trying to collect small fixes here while the big PR is merged.

Will rebase this after.

Currently in:
* Refactoring mediaManager to playerManager because it's called that in CAF.
* HLS doesn't allow wider streams than the window rez, so limit to window.innerWIdth instead of by device maximums
  * TODO: We should do the same for height, I think portrait mode videos would break without that.
  * TODO: this is bad for directplay and non-hls playback, we should consider reverting this and make mkv the only way to play video. Tough choices ahead. I left the old code commented so it can be easily restored.
* Receiver ID is set after the initial capabilities are reporting, resulting in two devices registered server side. Refactored that inside of JellyfinApi to get it under control and reordered it just a bit more so it obeys the bitrate limit as well (hopefully). Fixes #43
* Getting rid of the extend() method, it just doesn't belong.
* Fixing start seek. Fixes #63
* Fixing playback position reporting
* Fixing stream change that requires transcoding to restart
* Don't tell CAF to completely stop after each item played back
* cap max bitrate to device spec as well.
* Improve bitrate measurement algorithm
* Refactor away window.playlist to get the playlist working
* Start in the middle of a playlist (options.startIndex)