### PR TITLE
Make chromecast stable work on 10.7

### DIFF
--- a/components/embyactions.js
+++ b/components/embyactions.js
@@ -196,8 +196,8 @@
         lastTranscoderPing = new Date().getTime();
 
         return fetchhelper.ajax({
-
-            url: url,
+            // 10.7 needs it there instead of in POST
+            url: url + '?playSessionId=' + options.PlaySessionId,
             headers: getSecurityHeaders($scope.accessToken, $scope.userId),
             type: 'POST',
             data: JSON.stringify(options),

--- a/components/maincontroller.js
+++ b/components/maincontroller.js
@@ -699,6 +699,17 @@
             Method: 'External'
         });
 
+        // clean up deviceprofile since in this version it's in the submodule.
+        for(var pi in profile.CodecProfiles) {
+            var p = profile.CodecProfiles[pi];
+            for(var ci in p.Conditions) {
+                var c = p.Conditions[ci];
+                if (c.IsRequired === 'false') {
+                    c.IsRequired = false;
+                }
+            }
+        }
+
         return profile;
     }
 

--- a/components/maincontroller.js
+++ b/components/maincontroller.js
@@ -170,7 +170,7 @@
 
         window.VolumeInfo.Level = (event.data['level'] || 1) * 100;
         window.VolumeInfo.IsMuted = event.data['muted'] || false;
-        
+
         if ($scope.userId != null) {
             reportEvent('volumechange', true);
         }
@@ -502,6 +502,12 @@
         console.log('Playlist message: ' + JSON.stringify(event));
 
         var data = event.data;
+
+        // Apparently chromium likes to pass it as json, not as object.
+        // chrome on android works fine
+        if (typeof data === 'string') {
+            data = JSON.parse(data);
+        }
 
         data.options = data.options || {};
         data.options.senderId = event.senderId;

--- a/helpers.js
+++ b/helpers.js
@@ -30,12 +30,12 @@ function getCurrentPositionTicks($scope) {
 function getReportingParams($scope) {
 
     return {
-        PositionTicks: getCurrentPositionTicks($scope),
+        PositionTicks: Math.round(getCurrentPositionTicks($scope)),
         IsPaused: window.mediaElement.paused,
         IsMuted: window.VolumeInfo.IsMuted,
         AudioStreamIndex: $scope.audioStreamIndex,
         SubtitleStreamIndex: $scope.subtitleStreamIndex,
-        VolumeLevel: window.VolumeInfo.Level,
+        VolumeLevel: Math.round(window.VolumeInfo.Level),
         ItemId: $scope.itemId,
         MediaSourceId: $scope.mediaSourceId,
         QueueableMediaTypes: ['Audio', 'Video'],


### PR DESCRIPTION
- backports the fix that makes it work on chromium
- fixes errors relating to 3 api endpoints

essentially this code goes in the trash when nightly gets to the point where it replaces stable.