### PR TITLE
Add tests for jellyfinApi

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+    globals: {
+        RECEIVERVERSION: 'thisIsVersionNumber'
+    },
     preset: 'ts-jest',
-    testEnvironment: 'node'
+    testEnvironment: 'jsdom'
 };

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "prepare": "npm run build:production",
         "prettier": "prettier --check .",
         "start": "TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack serve --config webpack.config.ts",
-        "test": "jest",
+        "test": "jest --silent",
         "watch": "TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack --config webpack.config.ts --watch"
     }
 }

--- a/src/components/__tests__/jellyfinApi.test.ts
+++ b/src/components/__tests__/jellyfinApi.test.ts
@@ -1,0 +1,240 @@
+import { JellyfinApi } from '../jellyfinApi';
+
+const setupMockCastSenders = (): void => {
+    const getSenders = (): Array<any> => [{ id: 'thisIsSenderId' }];
+    const getInstance = (): any => ({ getSenders });
+
+    // @ts-expect-error cast is already defined globally, however since we're mocking it we need to redefine it.
+    global.cast = {
+        framework: {
+            CastReceiverContext: {
+                getInstance
+            }
+        }
+    };
+};
+
+describe('creating basic urls', () => {
+    beforeAll(() => {
+        setupMockCastSenders();
+    });
+
+    beforeEach(() => {
+        JellyfinApi.setServerInfo(
+            'thisIsUserId',
+            'thisIsAccessToken',
+            'thisIsServerAddress'
+        );
+    });
+
+    test('should return correct url', () => {
+        const result = JellyfinApi.createUrl('somePath');
+        const correct = 'thisIsServerAddress/somePath';
+
+        expect(result).toEqual(correct);
+    });
+
+    test('should remove leading slashes', () => {
+        const result = JellyfinApi.createUrl('///////somePath');
+        const correct = 'thisIsServerAddress/somePath';
+
+        expect(result).toEqual(correct);
+    });
+
+    test('should return empty string on undefined serverAddress', () => {
+        JellyfinApi.setServerInfo();
+
+        const result = JellyfinApi.createUrl('somePath');
+        const correct = '';
+
+        expect(result).toEqual(correct);
+    });
+});
+
+describe('creating user urls', () => {
+    beforeAll(() => {
+        setupMockCastSenders();
+    });
+
+    beforeEach(() => {
+        JellyfinApi.setServerInfo(
+            'thisIsUserId',
+            'thisIsAccessToken',
+            'thisIsServerAddress'
+        );
+    });
+
+    test('should return correct url', () => {
+        const result = JellyfinApi.createUserUrl('somePath');
+        const correct = 'thisIsServerAddress/Users/thisIsUserId/somePath';
+
+        expect(result).toEqual(correct);
+    });
+
+    test('should remove leading slashes', () => {
+        const result = JellyfinApi.createUserUrl('////////somePath');
+        const correct = 'thisIsServerAddress/Users/thisIsUserId/somePath';
+
+        expect(result).toEqual(correct);
+    });
+
+    test('should return empty string on undefined serverAddress', () => {
+        JellyfinApi.setServerInfo();
+
+        const result = JellyfinApi.createUserUrl('somePath');
+        const correct = '';
+
+        expect(result).toEqual(correct);
+    });
+});
+
+describe('creating image urls', () => {
+    beforeAll(() => {
+        setupMockCastSenders();
+    });
+
+    beforeEach(() => {
+        JellyfinApi.setServerInfo(
+            'thisIsUserId',
+            'thisIsAccessToken',
+            'thisIsServerAddress'
+        );
+    });
+
+    test('should return correct url with all parameters provided', () => {
+        const itemId = '1';
+        const imageType = 'Primary';
+        const imageTag = 'sampleTag';
+        const imdIdx = 0;
+
+        const result = JellyfinApi.createImageUrl(
+            itemId,
+            imageType,
+            imageTag,
+            imdIdx
+        );
+        const correct = `thisIsServerAddress/Items/${itemId}/Images/${imageType}/${imdIdx.toString()}?tag=${imageTag}`;
+
+        expect(result).toEqual(correct);
+    });
+
+    test('should return correct url with minimal parameters provided', () => {
+        const itemId = '1';
+        const imageType = 'Primary';
+        const imageTag = 'sampleTag';
+        const imdIdx = 0;
+
+        const result = JellyfinApi.createImageUrl(itemId, imageType, imageTag);
+        const correct = `thisIsServerAddress/Items/${itemId}/Images/${imageType}/${imdIdx.toString()}?tag=${imageTag}`;
+
+        expect(result).toEqual(correct);
+    });
+
+    test('should return empty string on undefined serverAddress', () => {
+        JellyfinApi.setServerInfo();
+
+        const result = JellyfinApi.createImageUrl('', '', '');
+        const correct = '';
+
+        expect(result).toEqual(correct);
+    });
+});
+
+describe('test authenticated ajax', () => {
+    beforeAll(() => {
+        setupMockCastSenders();
+    });
+
+    test('should return rejected promise when server info is undefined', async () => {
+        // Linting requires this weird spacing.
+        JellyfinApi.setServerInfo(undefined, '', '');
+
+        const resultUserIdIsNull = JellyfinApi.authAjax('', {});
+
+        JellyfinApi.setServerInfo('', undefined, '');
+
+        const resultAccessTokenIsNull = JellyfinApi.authAjax('', {});
+
+        JellyfinApi.setServerInfo('', '', undefined);
+
+        const resultServerAddressIsNull = JellyfinApi.authAjax('', {});
+
+        await expect(resultUserIdIsNull).rejects.toEqual(
+            'no server info present'
+        );
+        await expect(resultAccessTokenIsNull).rejects.toEqual(
+            'no server info present'
+        );
+        await expect(resultServerAddressIsNull).rejects.toEqual(
+            'no server info present'
+        );
+    });
+});
+
+describe('test authenticated user ajax', () => {
+    test('should return rejected promise when server info is undefined', async () => {
+        // Linting requires this weird spacing.
+        JellyfinApi.setServerInfo(undefined, '', '');
+
+        const resultUserIdIsNull = JellyfinApi.authAjaxUser('', {});
+
+        JellyfinApi.setServerInfo('', undefined, '');
+
+        const resultAccessTokenIsNull = JellyfinApi.authAjaxUser('', {});
+
+        JellyfinApi.setServerInfo('', '');
+
+        const resultServerAddressIsNull = JellyfinApi.authAjaxUser('', {});
+
+        await expect(resultUserIdIsNull).rejects.toEqual(
+            'no server info present'
+        );
+        await expect(resultAccessTokenIsNull).rejects.toEqual(
+            'no server info present'
+        );
+        await expect(resultServerAddressIsNull).rejects.toEqual(
+            'no server info present'
+        );
+    });
+});
+
+describe('getting security headers', () => {
+    beforeAll(() => {
+        setupMockCastSenders();
+    });
+
+    test('should return correct auth header with all server details set', () => {
+        JellyfinApi.setServerInfo(
+            'thisIsUserId',
+            'thisIsAccessToken',
+            'thisIsServerAddress',
+            'thisIsReceiverName'
+        );
+
+        // @ts-expect-error Since the method is private.
+        const result = JellyfinApi.getSecurityHeaders();
+        const correctAuth = `Jellyfin Client="Chromecast", Device="thisIsReceiverName", DeviceId="${btoa(
+            'thisIsReceiverName'
+        )}", Version="thisIsVersionNumber", UserId="thisIsUserId"`;
+
+        expect(result).toHaveProperty('X-MediaBrowser-Token');
+        expect(result).toHaveProperty('Authorization');
+        expect(result.Authorization).toMatch(correctAuth);
+    });
+
+    test('should return correct auth header with minimal server details set', () => {
+        JellyfinApi.setServerInfo(
+            undefined,
+            'thisIsAccessToken',
+            'thisIsServerAddress'
+        );
+
+        // @ts-expect-error Since the method is private.
+        const result = JellyfinApi.getSecurityHeaders();
+        const correct = {
+            Authorization: `Jellyfin Client="Chromecast", Device="Google Cast", DeviceId="thisIsSenderId", Version="thisIsVersionNumber"`
+        };
+
+        expect(result).toMatchObject(correct);
+    });
+});

--- a/src/components/jellyfinApi.ts
+++ b/src/components/jellyfinApi.ts
@@ -3,13 +3,13 @@ import { Dictionary } from '~/types/global';
 
 export abstract class JellyfinApi {
     // userId that we are connecting as currently
-    public static userId: string | null = null;
+    public static userId: string | undefined;
 
     // Security token to prove authentication
-    public static accessToken: string | null = null;
+    public static accessToken: string | undefined;
 
     // Address of server
-    public static serverAddress: string | null = null;
+    public static serverAddress: string | undefined;
 
     // device name
     public static deviceName = 'Google Cast';
@@ -21,9 +21,9 @@ export abstract class JellyfinApi {
     public static versionNumber = RECEIVERVERSION;
 
     public static setServerInfo(
-        userId: string,
-        accessToken: string,
-        serverAddress: string,
+        userId?: string,
+        accessToken?: string,
+        serverAddress?: string,
         receiverName = ''
     ): void {
         console.debug(
@@ -69,7 +69,7 @@ export abstract class JellyfinApi {
             Authorization: auth
         };
 
-        if (this.accessToken != null) {
+        if (this.accessToken != undefined) {
             headers['X-MediaBrowser-Token'] = this.accessToken;
         }
 
@@ -79,7 +79,7 @@ export abstract class JellyfinApi {
     // Create a basic url.
     // Cannot start with /.
     public static createUrl(path: string): string {
-        if (this.serverAddress === null) {
+        if (this.serverAddress === undefined) {
             console.error('JellyfinApi.createUrl: no server address present');
 
             return '';
@@ -96,6 +96,11 @@ export abstract class JellyfinApi {
     // create a path in /Users/userId/ <path>
     public static createUserUrl(path: string | null = null): string {
         if (path) {
+            // Remove leading slashes
+            while (path.charAt(0) === '/') {
+                path = path.substring(1);
+            }
+
             return this.createUrl(`Users/${this.userId}/${path}`);
         } else {
             return this.createUrl(`Users/${this.userId}`);
@@ -125,9 +130,9 @@ export abstract class JellyfinApi {
     // Authenticated ajax
     public static authAjax(path: string, args: any): Promise<any> {
         if (
-            this.userId === null ||
-            this.accessToken === null ||
-            this.serverAddress === null
+            this.userId === undefined ||
+            this.accessToken === undefined ||
+            this.serverAddress === undefined
         ) {
             console.error(
                 'JellyfinApi.authAjax: No userid/accesstoken/serverAddress present. Skipping request'
@@ -147,9 +152,9 @@ export abstract class JellyfinApi {
     // Authenticated ajax
     public static authAjaxUser(path: string, args: any): Promise<any> {
         if (
-            this.userId === null ||
-            this.accessToken === null ||
-            this.serverAddress === null
+            this.userId === undefined ||
+            this.accessToken === undefined ||
+            this.serverAddress === undefined
         ) {
             console.error(
                 'JellyfinApi.authAjaxUser: No userid/accesstoken/serverAddress present. Skipping request'


### PR DESCRIPTION
Change  `JellyfinApi.setServerInfo` parameters to accept null.
Add `--silent` to test command. This will silence output printed via `console`
Add check to remove leading slashes from `path` parameter in `JellyfinApi.createImageUrl`.
Add basic tests to `JellyfinApi`.
Change test environment to `jsdom` as that provides a more browser-like test environment.
Define `RECEIVERVERSION` globally for tests. Since we're not running the code through webpack, this variable will never be replaced and jest will get angry.