### PR TITLE
Rework scope

### DIFF
--- a/src/components/commandHandler.ts
+++ b/src/components/commandHandler.ts
@@ -110,11 +110,17 @@ export abstract class CommandHandler {
     }
 
     static setAudioStreamIndexHandler(data: DataMessage): void {
-        setAudioStreamIndex($scope, (<SetIndexRequest>data.options).index);
+        setAudioStreamIndex(
+            this.playbackManager.playbackState,
+            (<SetIndexRequest>data.options).index
+        );
     }
 
     static setSubtitleStreamIndexHandler(data: DataMessage): void {
-        setSubtitleStreamIndex($scope, (<SetIndexRequest>data.options).index);
+        setSubtitleStreamIndex(
+            this.playbackManager.playbackState,
+            (<SetIndexRequest>data.options).index
+        );
     }
 
     // VolumeUp, VolumeDown and ToggleMute commands seem to be handled on the sender in the current implementation.
@@ -143,8 +149,8 @@ export abstract class CommandHandler {
         } else {
             // When a client connects send back the initial device state (volume etc) via a playbackstop message
             reportPlaybackProgress(
-                $scope,
-                getReportingParams($scope),
+                this.playbackManager.playbackState,
+                getReportingParams(this.playbackManager.playbackState),
                 true,
                 'playbackstop'
             );
@@ -152,7 +158,10 @@ export abstract class CommandHandler {
     }
 
     static SeekHandler(data: DataMessage): void {
-        seek((<SeekRequest>data.options).position * 10000000);
+        seek(
+            this.playbackManager.playbackState,
+            (<SeekRequest>data.options).position * 10000000
+        );
     }
 
     static MuteHandler(): void {

--- a/src/components/jellyfinActions.ts
+++ b/src/components/jellyfinActions.ts
@@ -1,10 +1,4 @@
-import {
-    getSenderReportingData,
-    resetPlaybackScope,
-    broadcastToMessageBus
-} from '../helpers';
-
-import { GlobalScope } from '../types/global';
+import { getSenderReportingData, broadcastToMessageBus } from '../helpers';
 import { PlaybackProgressInfo } from '../api/generated/models/playback-progress-info';
 import { BaseItemDto } from '../api/generated/models/base-item-dto';
 import { DeviceProfile } from '../api/generated/models/device-profile';
@@ -13,6 +7,7 @@ import { PlayRequest } from '../api/generated/models/play-request';
 import { LiveStreamResponse } from '../api/generated/models/live-stream-response';
 import { JellyfinApi } from './jellyfinApi';
 import { DocumentManager } from './documentManager';
+import { playbackManager, PlaybackState } from './playbackManager';
 
 interface PlayRequestQuery extends PlayRequest {
     UserId?: string;
@@ -31,13 +26,9 @@ let lastTranscoderPing = 0;
  *
  * This is used to keep the transcode available during pauses
  *
- * @param $scope - global context
  * @param reportingParams - parameters to report to the server
  */
-function restartPingInterval(
-    $scope: GlobalScope,
-    reportingParams: PlaybackProgressInfo
-): void {
+function restartPingInterval(reportingParams: PlaybackProgressInfo): void {
     stopPingInterval();
 
     if (reportingParams.PlayMethod == 'Transcode') {
@@ -62,12 +53,12 @@ export function stopPingInterval(): void {
 /**
  * Report to the server that playback has started.
  *
- * @param $scope - global scope
+ * @param state - playback state.
  * @param reportingParams - parameters to send to the server
  * @returns promise to wait for the request
  */
 export function reportPlaybackStart(
-    $scope: GlobalScope,
+    state: PlaybackState,
     reportingParams: PlaybackProgressInfo
 ): Promise<void> {
     // it's just "reporting" that the playback is starting
@@ -78,11 +69,11 @@ export function reportPlaybackStart(
 
     broadcastToMessageBus({
         //TODO: convert these to use a defined type in the type field
-        data: getSenderReportingData($scope, reportingParams),
+        data: getSenderReportingData(state, reportingParams),
         type: 'playbackstart'
     });
 
-    restartPingInterval($scope, reportingParams);
+    restartPingInterval(reportingParams);
 
     return JellyfinApi.authAjax('Sessions/Playing', {
         contentType: 'application/json',
@@ -94,20 +85,20 @@ export function reportPlaybackStart(
 /**
  * Report to the server the progress of the playback.
  *
- * @param $scope - global scope
+ * @param state - playback state.
  * @param reportingParams - parameters for jellyfin
  * @param reportToServer - if jellyfin should be informed
  * @param broadcastEventName - name of event to send to the cast sender
  * @returns Promise for the http request
  */
 export function reportPlaybackProgress(
-    $scope: GlobalScope,
+    state: PlaybackState,
     reportingParams: PlaybackProgressInfo,
     reportToServer = true,
     broadcastEventName = 'playbackprogress'
 ): Promise<void> {
     broadcastToMessageBus({
-        data: getSenderReportingData($scope, reportingParams),
+        data: getSenderReportingData(state, reportingParams),
         type: broadcastEventName
     });
 
@@ -115,7 +106,7 @@ export function reportPlaybackProgress(
         return Promise.resolve();
     }
 
-    restartPingInterval($scope, reportingParams);
+    restartPingInterval(reportingParams);
     lastTranscoderPing = new Date().getTime();
 
     return JellyfinApi.authAjax('Sessions/Playing/Progress', {
@@ -128,18 +119,18 @@ export function reportPlaybackProgress(
 /**
  * Report to the server that playback has stopped.
  *
- * @param $scope - global scope
+ * @param state - playback state.
  * @param reportingParams - parameters to send to the server
  * @returns promise for waiting for the request
  */
 export function reportPlaybackStopped(
-    $scope: GlobalScope,
+    state: PlaybackState,
     reportingParams: PlaybackProgressInfo
 ): Promise<void> {
     stopPingInterval();
 
     broadcastToMessageBus({
-        data: getSenderReportingData($scope, reportingParams),
+        data: getSenderReportingData(state, reportingParams),
         type: 'playbackstop'
     });
 
@@ -192,33 +183,35 @@ export function pingTranscoder(
 /**
  * Update the context about the item we are playing.
  *
- * @param $scope - global context
- * @param customData - data to set on $scope
+ * @param playbackMgr - playback manager.
+ * @param customData - data to set on playback state.
  * @param serverItem - item that is playing
  */
 export function load(
-    $scope: GlobalScope,
+    playbackMgr: playbackManager,
     customData: any,
     serverItem: BaseItemDto
 ): void {
-    resetPlaybackScope($scope);
+    playbackMgr.resetPlaybackScope();
+
+    const state = playbackMgr.playbackState;
 
     // These are set up in maincontroller.createMediaInformation
-    $scope.playSessionId = customData.playSessionId;
-    $scope.audioStreamIndex = customData.audioStreamIndex;
-    $scope.subtitleStreamIndex = customData.subtitleStreamIndex;
-    $scope.startPositionTicks = customData.startPositionTicks;
-    $scope.canSeek = customData.canSeek;
-    $scope.itemId = customData.itemId;
-    $scope.liveStreamId = customData.liveStreamId;
-    $scope.mediaSourceId = customData.mediaSourceId;
-    $scope.playMethod = customData.playMethod;
-    $scope.runtimeTicks = customData.runtimeTicks;
+    state.playSessionId = customData.playSessionId;
+    state.audioStreamIndex = customData.audioStreamIndex;
+    state.subtitleStreamIndex = customData.subtitleStreamIndex;
+    state.startPositionTicks = customData.startPositionTicks;
+    state.canSeek = customData.canSeek;
+    state.itemId = customData.itemId;
+    state.liveStreamId = customData.liveStreamId;
+    state.mediaSourceId = customData.mediaSourceId;
+    state.playMethod = customData.playMethod;
+    state.runtimeTicks = customData.runtimeTicks;
 
-    $scope.item = serverItem;
+    state.item = serverItem;
 
     DocumentManager.setAppStatus('backdrop');
-    $scope.mediaType = serverItem?.MediaType;
+    state.mediaType = serverItem?.MediaType;
 }
 
 /**
@@ -229,9 +222,9 @@ export function load(
  *
  * TODO: rename these
  *
- * @param $scope - global scope
+ * @param state - playback state.
  */
-export function play($scope: GlobalScope): void {
+export function play(state: PlaybackState): void {
     if (
         DocumentManager.getAppStatus() == 'backdrop' ||
         DocumentManager.getAppStatus() == 'playing-with-controls' ||
@@ -241,7 +234,7 @@ export function play($scope: GlobalScope): void {
         setTimeout(() => {
             window.playerManager.play();
 
-            if ($scope.mediaType == 'Audio') {
+            if (state.mediaType == 'Audio') {
                 DocumentManager.setAppStatus('audio');
             } else {
                 DocumentManager.setAppStatus('playing-with-controls');
@@ -413,17 +406,17 @@ export async function detectBitrate(): Promise<number> {
 /**
  * Tell Jellyfin to kill off our active transcoding session
  *
- * @param $scope - Global scope variable
+ * @param state - playback state.
  * @returns Promise for the http request to go through
  */
-export function stopActiveEncodings($scope: GlobalScope): Promise<void> {
+export function stopActiveEncodings(state: PlaybackState): Promise<void> {
     const options = {
         deviceId: JellyfinApi.deviceId,
-        PlaySessionId: undefined
+        PlaySessionId: ''
     };
 
-    if ($scope.playSessionId) {
-        options.PlaySessionId = $scope.playSessionId;
+    if (state.playSessionId) {
+        options.PlaySessionId = state.playSessionId;
     }
 
     return JellyfinApi.authAjax('Videos/ActiveEncodings', {

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -26,7 +26,7 @@ import { getMaxBitrateSupport } from './codecSupportHelper';
 import { DocumentManager } from './documentManager';
 import { BaseItemDto } from '~/api/generated/models/base-item-dto';
 import { MediaSourceInfo } from '~/api/generated/models/media-source-info';
-import { GlobalScope, PlayRequest } from '~/types/global';
+import { PlayRequest } from '~/types/global';
 
 window.castReceiverContext = cast.framework.CastReceiverContext.getInstance();
 window.playerManager = window.castReceiverContext.getPlayerManager();

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -1,7 +1,6 @@
 import {
     getCurrentPositionTicks,
     getReportingParams,
-    resetPlaybackScope,
     getMetadata,
     createStreamInfo,
     getStreamByIndex,
@@ -21,7 +20,7 @@ import {
 } from './jellyfinActions';
 import { getDeviceProfile } from './deviceprofileBuilder';
 import { JellyfinApi } from './jellyfinApi';
-import { playbackManager } from './playbackManager';
+import { playbackManager, PlaybackState } from './playbackManager';
 import { CommandHandler } from './commandHandler';
 import { getMaxBitrateSupport } from './codecSupportHelper';
 import { DocumentManager } from './documentManager';
@@ -36,7 +35,7 @@ const playbackMgr = new playbackManager(window.playerManager);
 
 CommandHandler.configure(window.playerManager, playbackMgr);
 
-resetPlaybackScope($scope);
+playbackMgr.resetPlaybackScope();
 
 let broadcastToServer = new Date();
 
@@ -46,21 +45,29 @@ let hasReportedCapabilities = false;
  *
  */
 export function onMediaElementTimeUpdate(): void {
-    if ($scope.isChangingStream) {
+    if (playbackMgr.playbackState.isChangingStream) {
         return;
     }
 
     const now = new Date();
 
     const elapsed = now.valueOf() - broadcastToServer.valueOf();
+    const playbackState = playbackMgr.playbackState;
 
     if (elapsed > 5000) {
         // TODO use status as input
-        reportPlaybackProgress($scope, getReportingParams($scope));
+        reportPlaybackProgress(
+            playbackState,
+            getReportingParams(playbackState)
+        );
         broadcastToServer = now;
     } else if (elapsed > 1500) {
         // TODO use status as input
-        reportPlaybackProgress($scope, getReportingParams($scope), false);
+        reportPlaybackProgress(
+            playbackState,
+            getReportingParams(playbackState),
+            false
+        );
     }
 }
 
@@ -68,7 +75,7 @@ export function onMediaElementTimeUpdate(): void {
  *
  */
 export function onMediaElementPause(): void {
-    if ($scope.isChangingStream) {
+    if (playbackMgr.playbackState.isChangingStream) {
         return;
     }
 
@@ -79,7 +86,7 @@ export function onMediaElementPause(): void {
  *
  */
 export function onMediaElementPlaying(): void {
-    if ($scope.isChangingStream) {
+    if (playbackMgr.playbackState.isChangingStream) {
         return;
     }
 
@@ -146,22 +153,34 @@ enableTimeUpdateListener();
 
 window.addEventListener('beforeunload', () => {
     // Try to cleanup after ourselves before the page closes
+    const playbackState = playbackMgr.playbackState;
+
     disableTimeUpdateListener();
-    reportPlaybackStopped($scope, getReportingParams($scope));
+    reportPlaybackStopped(playbackState, getReportingParams(playbackState));
 });
 
 window.playerManager.addEventListener(
     cast.framework.events.EventType.PLAY,
     (): void => {
-        play($scope);
-        reportPlaybackProgress($scope, getReportingParams($scope));
+        const playbackState = playbackMgr.playbackState;
+
+        play(playbackState);
+        reportPlaybackProgress(
+            playbackState,
+            getReportingParams(playbackState)
+        );
     }
 );
 
 window.playerManager.addEventListener(
     cast.framework.events.EventType.PAUSE,
     (): void => {
-        reportPlaybackProgress($scope, getReportingParams($scope));
+        const playbackState = playbackMgr.playbackState;
+
+        reportPlaybackProgress(
+            playbackState,
+            getReportingParams(playbackState)
+        );
     }
 );
 
@@ -184,13 +203,15 @@ window.playerManager.addEventListener(
 window.playerManager.addEventListener(
     cast.framework.events.EventType.ENDED,
     (): void => {
+        const playbackState = playbackMgr.playbackState;
+
         // If we're changing streams, do not report playback ended.
-        if ($scope.isChangingStream) {
+        if (playbackState.isChangingStream) {
             return;
         }
 
-        reportPlaybackStopped($scope, getReportingParams($scope));
-        resetPlaybackScope($scope);
+        reportPlaybackStopped(playbackState, getReportingParams(playbackState));
+        playbackMgr.resetPlaybackScope();
 
         if (!playbackMgr.playNextItem()) {
             window.playlist = [];
@@ -286,15 +307,22 @@ export function processMessage(data: any): void {
     CommandHandler.processMessage(data, data.command);
 
     if (window.reportEventType) {
-        const report = (): Promise<void> =>
-            reportPlaybackProgress($scope, getReportingParams($scope));
+        const playbackState = playbackMgr.playbackState;
+
+        const report = (): void => {
+            reportPlaybackProgress(
+                playbackState,
+                getReportingParams(playbackState)
+            );
+        };
 
         reportPlaybackProgress(
-            $scope,
-            getReportingParams($scope),
+            playbackState,
+            getReportingParams(playbackState),
             true,
             window.reportEventType
         );
+
         setTimeout(report, 100);
         setTimeout(report, 500);
     }
@@ -308,33 +336,35 @@ export function reportEvent(
     name: string,
     reportToServer: boolean
 ): Promise<void> {
+    const playbackState = playbackMgr.playbackState;
+
     return reportPlaybackProgress(
-        $scope,
-        getReportingParams($scope),
+        playbackState,
+        getReportingParams(playbackState),
         reportToServer,
         name
     );
 }
 
 /**
- * @param $scope
+ * @param state - playback state.
  * @param index
  */
 export function setSubtitleStreamIndex(
-    $scope: GlobalScope,
+    state: PlaybackState,
     index: number
 ): void {
     console.log(`setSubtitleStreamIndex. index: ${index}`);
 
     let positionTicks;
 
-    const currentSubtitleStream = $scope.mediaSource.MediaStreams.filter(
+    // FIXME: Possible index error when MediaStreams is undefined.
+    const currentSubtitleStream = state.mediaSource?.MediaStreams?.filter(
         (m: any) => {
-            return (
-                m.Index == $scope.subtitleStreamIndex && m.Type == 'Subtitle'
-            );
+            return m.Index == state.subtitleStreamIndex && m.Type == 'Subtitle';
         }
     )[0];
+
     const currentDeliveryMethod = currentSubtitleStream
         ? currentSubtitleStream.DeliveryMethod
         : null;
@@ -343,21 +373,25 @@ export function setSubtitleStreamIndex(
         // Need to change the stream to turn off the subs
         if (currentDeliveryMethod == 'Encode') {
             console.log('setSubtitleStreamIndex video url change required');
-            positionTicks = getCurrentPositionTicks($scope);
-            changeStream(positionTicks, {
+            positionTicks = getCurrentPositionTicks(state);
+            changeStream(state, positionTicks, {
                 SubtitleStreamIndex: -1
             });
         } else {
-            $scope.subtitleStreamIndex = -1;
+            state.subtitleStreamIndex = -1;
             setTextTrack(null);
         }
 
         return;
     }
 
-    const mediaStreams = $scope.PlaybackMediaSource.MediaStreams;
+    const mediaStreams = state.PlaybackMediaSource?.MediaStreams;
 
-    const subtitleStream = getStreamByIndex(mediaStreams, 'Subtitle', index);
+    const subtitleStream = getStreamByIndex(
+        <any>mediaStreams,
+        'Subtitle',
+        index
+    );
 
     if (!subtitleStream) {
         console.log(
@@ -381,45 +415,48 @@ export function setSubtitleStreamIndex(
 
         console.log(`Subtitle url: ${textStreamUrl}`);
         setTextTrack(index);
-        $scope.subtitleStreamIndex = subtitleStream.Index;
+        state.subtitleStreamIndex = subtitleStream.Index;
 
         return;
     } else {
         console.log('setSubtitleStreamIndex video url change required');
-        positionTicks = getCurrentPositionTicks($scope);
-        changeStream(positionTicks, {
+        positionTicks = getCurrentPositionTicks(state);
+        changeStream(state, positionTicks, {
             SubtitleStreamIndex: index
         });
     }
 }
 
 /**
- * @param $scope
+ * @param state - playback state.
  * @param index
  */
 export function setAudioStreamIndex(
-    $scope: GlobalScope,
+    state: PlaybackState,
     index: number
 ): Promise<void> {
-    const positionTicks = getCurrentPositionTicks($scope);
+    const positionTicks = getCurrentPositionTicks(state);
 
-    return changeStream(positionTicks, {
+    return changeStream(state, positionTicks, {
         AudioStreamIndex: index
     });
 }
 
 /**
+ * @param state - playback state.
  * @param ticks
  */
-export function seek(ticks: number): Promise<void> {
-    return changeStream(ticks);
+export function seek(state: PlaybackState, ticks: number): Promise<void> {
+    return changeStream(state, ticks);
 }
 
 /**
+ * @param state - playback state.
  * @param ticks
  * @param params
  */
 export async function changeStream(
+    state: PlaybackState,
     ticks: number,
     params: any = undefined
 ): Promise<void> {
@@ -428,17 +465,17 @@ export async function changeStream(
         params == null
     ) {
         window.playerManager.seek(ticks / 10000000);
-        reportPlaybackProgress($scope, getReportingParams($scope));
+        reportPlaybackProgress(state, getReportingParams(state));
 
         return Promise.resolve();
     }
 
     params = params || {};
 
-    const playSessionId = $scope.playSessionId;
-    const liveStreamId = $scope.liveStreamId;
+    const playSessionId = state.playSessionId;
+    const liveStreamId = state.liveStreamId;
 
-    const item = $scope.item;
+    const item = state.item;
     const maxBitrate = await getMaxBitrate();
 
     const deviceProfile = getDeviceProfile({
@@ -447,19 +484,19 @@ export async function changeStream(
     });
     const audioStreamIndex =
         params.AudioStreamIndex == null
-            ? $scope.audioStreamIndex
+            ? state.audioStreamIndex
             : params.AudioStreamIndex;
     const subtitleStreamIndex =
         params.SubtitleStreamIndex == null
-            ? $scope.subtitleStreamIndex
+            ? state.subtitleStreamIndex
             : params.SubtitleStreamIndex;
 
     const playbackInformation = await getPlaybackInfo(
-        item,
+        <BaseItemDto>item,
         maxBitrate,
         deviceProfile,
         ticks,
-        $scope.mediaSourceId,
+        state.mediaSourceId,
         audioStreamIndex,
         subtitleStreamIndex,
         liveStreamId
@@ -470,7 +507,7 @@ export async function changeStream(
     }
 
     const mediaSource = playbackInformation.MediaSources[0];
-    const streamInfo = createStreamInfo(item, mediaSource, ticks);
+    const streamInfo = createStreamInfo(<BaseItemDto>item, mediaSource, ticks);
 
     if (!streamInfo.url) {
         showPlaybackInfoErrorMessage('NoCompatibleStream');
@@ -480,7 +517,7 @@ export async function changeStream(
 
     const mediaInformation = createMediaInformation(
         playSessionId,
-        item,
+        <BaseItemDto>item,
         streamInfo
     );
     const loadRequest = new cast.framework.messages.LoadRequestData();
@@ -493,13 +530,13 @@ export async function changeStream(
 
     if (requiresStoppingTranscoding) {
         window.playerManager.pause();
-        await stopActiveEncodings(playSessionId);
+        await stopActiveEncodings(state);
     }
 
     window.playerManager.load(loadRequest);
     window.playerManager.play();
-    $scope.subtitleStreamIndex = subtitleStreamIndex;
-    $scope.audioStreamIndex = audioStreamIndex;
+    state.subtitleStreamIndex = subtitleStreamIndex;
+    state.audioStreamIndex = audioStreamIndex;
 }
 
 // Create a message handler for the custome namespace channel

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -298,4 +298,35 @@ export class playbackManager {
 
         return promise;
     }
+
+    /**
+     * Attempt to clean the receiver state.
+     */
+    resetPlaybackScope(): void {
+        DocumentManager.setAppStatus('waiting');
+
+        this.playbackState.startPositionTicks = 0;
+        DocumentManager.setWaitingBackdrop(null, null);
+        this.playbackState.mediaType = '';
+        this.playbackState.itemId = '';
+
+        this.playbackState.audioStreamIndex = null;
+        this.playbackState.subtitleStreamIndex = null;
+        this.playbackState.mediaSource = null;
+        this.playbackState.mediaSourceId = '';
+        this.playbackState.PlaybackMediaSource = null;
+
+        this.playbackState.playMethod = undefined;
+        this.playbackState.canSeek = false;
+        this.playbackState.isChangingStream = false;
+        this.playbackState.playNextItemBool = true;
+
+        this.playbackState.item = null;
+        this.playbackState.liveStreamId = '';
+        this.playbackState.playSessionId = '';
+
+        // Detail content
+        DocumentManager.setLogo(null);
+        DocumentManager.setDetailImage(null);
+    }
 }

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -37,7 +37,7 @@ export interface PlaybackState {
     itemId: string;
 
     audioStreamIndex: null;
-    subtitleStreamIndex: null;
+    subtitleStreamIndex: number | null;
     mediaSource: MediaSourceInfo | null;
     mediaSourceId: string;
     PlaybackMediaSource: MediaSourceInfo | null;
@@ -256,7 +256,7 @@ export class playbackManager {
         loadRequestData.media = mediaInfo;
         loadRequestData.autoplay = true;
 
-        load($scope, mediaInfo.customData, item);
+        load(this, mediaInfo.customData, item);
         this.playerManager.load(loadRequestData);
 
         this.playbackState.PlaybackMediaSource = mediaSource;
@@ -266,7 +266,10 @@ export class playbackManager {
 
         DocumentManager.setPlayerBackdrop(item);
 
-        reportPlaybackStart($scope, getReportingParams($scope));
+        reportPlaybackStart(
+            this.playbackState,
+            getReportingParams(this.playbackState)
+        );
 
         // We use false as we do not want to broadcast the new status yet
         // we will broadcast manually when the media has been loaded, this
@@ -278,14 +281,17 @@ export class playbackManager {
         this.playbackState.playNextItemBool = continuing;
         stop();
 
-        const reportingParams = getReportingParams($scope);
+        const reportingParams = getReportingParams(this.playbackState);
 
         let promise;
 
         stopPingInterval();
 
         if (reportingParams.ItemId) {
-            promise = reportPlaybackStopped($scope, reportingParams);
+            promise = reportPlaybackStopped(
+                this.playbackState,
+                reportingParams
+            );
         }
 
         this.playerManager.stop();

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -29,12 +29,55 @@ import {
 import { DocumentManager } from './documentManager';
 import { BaseItemDto } from '~/api/generated/models/base-item-dto';
 import { MediaSourceInfo } from '~/api/generated/models/media-source-info';
+import { PlayMethod } from '~/api/generated';
+
+export interface PlaybackState {
+    startPositionTicks: number;
+    mediaType: string | null | undefined;
+    itemId: string;
+
+    audioStreamIndex: null;
+    subtitleStreamIndex: null;
+    mediaSource: MediaSourceInfo | null;
+    mediaSourceId: string;
+    PlaybackMediaSource: MediaSourceInfo | null;
+
+    playMethod: PlayMethod | undefined;
+    canSeek: boolean;
+    isChangingStream: boolean;
+    playNextItemBool: boolean;
+
+    item: BaseItemDto | null;
+    liveStreamId: string;
+    playSessionId: string;
+
+    runtimeTicks: number;
+}
 
 export class playbackManager {
     private playerManager: framework.PlayerManager;
     // TODO remove any
     private activePlaylist: Array<BaseItemDto>;
     private activePlaylistIndex: number;
+
+    playbackState: PlaybackState = {
+        audioStreamIndex: null,
+        canSeek: false,
+        isChangingStream: false,
+        item: null,
+        itemId: '',
+        liveStreamId: '',
+        mediaSource: null,
+        mediaSourceId: '',
+        mediaType: '',
+        PlaybackMediaSource: null,
+        playMethod: undefined,
+        playNextItemBool: true,
+        playSessionId: '',
+        runtimeTicks: 0,
+        startPositionTicks: 0,
+        subtitleStreamIndex: null
+    };
 
     constructor(playerManager: framework.PlayerManager) {
         // Parameters
@@ -128,7 +171,7 @@ export class playbackManager {
     }
 
     async playItemInternal(item: BaseItemDto, options: any): Promise<void> {
-        $scope.isChangingStream = false;
+        this.playbackState.isChangingStream = false;
         DocumentManager.setAppStatus('loading');
 
         const maxBitrate = await getMaxBitrate();
@@ -216,10 +259,10 @@ export class playbackManager {
         load($scope, mediaInfo.customData, item);
         this.playerManager.load(loadRequestData);
 
-        $scope.PlaybackMediaSource = mediaSource;
+        this.playbackState.PlaybackMediaSource = mediaSource;
 
         console.log(`setting src to ${url}`);
-        $scope.mediaSource = mediaSource;
+        this.playbackState.mediaSource = mediaSource;
 
         DocumentManager.setPlayerBackdrop(item);
 
@@ -232,7 +275,7 @@ export class playbackManager {
     }
 
     stop(continuing = false): Promise<any> {
-        $scope.playNextItem = continuing;
+        this.playbackState.playNextItemBool = continuing;
         stop();
 
         const reportingParams = getReportingParams($scope);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,4 @@
 import { JellyfinApi } from './components/jellyfinApi';
-import { DocumentManager } from './components/documentManager';
-
 import { BaseItemDtoQueryResult } from './api/generated/models/base-item-dto-query-result';
 import { PlaybackProgressInfo } from './api/generated/models/playback-progress-info';
 import { MediaSourceInfo } from './api/generated/models/media-source-info';
@@ -205,39 +203,6 @@ export function getSenderReportingData(
     }
 
     return state;
-}
-
-/**
- * Attempt to clean the receiver state.
- *
- * @param $scope - global context variable
- */
-export function resetPlaybackScope($scope: GlobalScope): void {
-    DocumentManager.setAppStatus('waiting');
-
-    $scope.startPositionTicks = 0;
-    DocumentManager.setWaitingBackdrop(null, null);
-    $scope.mediaType = '';
-    $scope.itemId = '';
-
-    $scope.audioStreamIndex = null;
-    $scope.subtitleStreamIndex = null;
-    $scope.mediaSource = null;
-    $scope.mediaSourceId = '';
-    $scope.PlaybackMediaSource = null;
-
-    $scope.playMethod = '';
-    $scope.canSeek = false;
-    $scope.isChangingStream = false;
-    $scope.playNextItem = true;
-
-    $scope.item = null;
-    $scope.liveStreamId = '';
-    $scope.playSessionId = '';
-
-    // Detail content
-    DocumentManager.setLogo(null);
-    DocumentManager.setDetailImage(null);
 }
 
 /**

--- a/src/index.html
+++ b/src/index.html
@@ -7,11 +7,6 @@
             @import url('https://fonts.googleapis.com/css?family=Quicksand');
         </style>
         <script src="//www.gstatic.com/cast/sdk/libs/caf_receiver/v3/cast_receiver_framework.js"></script>
-        <script>
-            // $scope has to be available before app.js for webpack imported modules to function
-            // TODO: Rework this
-            $scope = {};
-        </script>
     </head>
     <body>
         <div id="waiting-container-backdrop"></div>

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -6,10 +6,6 @@ import { SystemVolumeData } from 'chromecast-caf-receiver/cast.framework.system'
 import { RepeatMode } from '../api/generated/models/repeat-mode';
 import { BaseItemDto } from '../api/generated/models/base-item-dto';
 
-export interface GlobalScope {
-    [key: string]: any;
-}
-
 export interface Dictionary<T> {
     [Key: string]: T;
 }
@@ -94,7 +90,6 @@ interface SupportedCommands {
 declare global {
     export const PRODUCTION: boolean;
     export const RECEIVERVERSION: string;
-    export const $scope: GlobalScope;
     export interface Window {
         mediaElement: HTMLElement | null;
         playerManager: PlayerManager;


### PR DESCRIPTION
The goal of this PR is to make scope less "global". This will not remove `$scope` as a concept completely, but it is a step in that direction.

Changes:
Create new interface with all scope variables called `PlaybackState`, stored in `playbackManager`.
Rework all functions using scope to either take `PlaybackState`, or `playbackManager` as a parameter. Allows for more reliable testing as it does not rely on globals anymore.