### PR TITLE
Remove intro implementation

### DIFF
--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -1,6 +1,5 @@
 import {
     getNextPlaybackItemInfo,
-    getIntros,
     broadcastConnectionErrorMessage,
     getReportingParams,
     createStreamInfo
@@ -66,10 +65,6 @@ export class playbackManager {
         if (options.startPositionTicks || firstItem.MediaType !== 'Video') {
             return this.playFromOptionsInternal(options);
         }
-
-        const intros = await getIntros(firstItem);
-
-        options.items = intros.Items?.concat(options.items);
 
         return this.playFromOptionsInternal(options);
     }


### PR DESCRIPTION
Intros are currently not very well implemented. The two removed lines gets and _appends_ the intros to the playlist (seems like intros should be first/in between each item rather than at the end).

I think this would be optimal to properly implement once we have CAF queue support as by that time we should have a lot less custom logic and different paths through the code (see: 5 play methods, all calling the next). We might be able to use CAF [Ad breaks](https://developers.google.com/cast/docs/web_receiver/ad_breaks) as a way to create a more native approach to intros.