### PR TITLE
Use cross-env in npm scripts to enable building on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,15 +69,15 @@
         "url": "git+https://github.com/jellyfin/jellyfin-chromecast.git"
     },
     "scripts": {
-        "build:development": "TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack --config webpack.config.ts --mode=development",
-        "build:production": "TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack --config webpack.config.ts --mode=production",
+        "build:development": "cross-env TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack --config webpack.config.ts --mode=development",
+        "build:production": "cross-env TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack --config webpack.config.ts --mode=production",
         "lint": "npm run lint:code && npm run lint:css && npm run prettier",
         "lint:code": "eslint --ext .ts,.js,.json .",
         "lint:css": "stylelint **/*.css",
         "prepare": "npm run build:production",
         "prettier": "prettier --check .",
-        "start": "TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack serve --config webpack.config.ts",
+        "start": "cross-env TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack serve --config webpack.config.ts",
         "test": "jest --silent",
-        "watch": "TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack --config webpack.config.ts --watch"
+        "watch": "cross-env TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack --config webpack.config.ts --watch"
     }
 }


### PR DESCRIPTION
This was removed in #117 without a reason. While building on Linux works fine without it, it's still required to be able to build properly on Windows (and possibly others).

Solves #293 