### PR TITLE
Seperate supported levels checks for h264 and h265

### DIFF
--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -121,38 +121,67 @@ export function getMaxWidthSupport(deviceId: number): number {
 }
 
 /**
- * Get all H.26x profiles supported by the active Cast device.
+ * Get all H.264 profiles supported by the active Cast device.
  *
  * @param deviceId - Cast device id.
- * @returns All supported H.26x profiles.
+ * @returns All supported H.264 profiles.
  */
-export function getH26xProfileSupport(deviceId: number): string {
+export function getH264ProfileSupport(deviceId: number): string {
     // These are supported by all Cast devices, excluding audio only devices.
-    let h26xProfiles = 'high|main|baseline|constrained baseline';
+    let h264Profiles = 'high|main|baseline|constrained baseline';
 
     if (deviceId === deviceIds.ULTRA || deviceId === deviceIds.CCGTV) {
-        h26xProfiles += '|high 10';
+        h264Profiles += '|high 10';
     }
 
-    return h26xProfiles;
+    return h264Profiles;
 }
 
 /**
- * Get the highest H.26x level supported by the active Cast device.
+ * Get the highest H.264 level supported by the active Cast device.
  *
  * @param deviceId - Cast device id.
- * @returns The highest supported H.26x level.
+ * @returns The highest supported H.264 level.
  */
-export function getH26xLevelSupport(deviceId: number): number {
+export function getH264LevelSupport(deviceId: number): number {
     switch (deviceId) {
         case deviceIds.NESTHUBANDMAX:
         case deviceIds.GEN1AND2:
             return 41;
         case deviceIds.GEN3:
-            return 42;
         case deviceIds.ULTRA:
+            return 42;
         case deviceIds.CCGTV:
-            return 52;
+            return 51;
+    }
+
+    return 0;
+}
+
+/**
+ * Get all H.265 profiles supported by the active Cast device.
+ *
+ * @param deviceId - Cast device id.
+ * @returns All supported H.265 profiles.
+ */
+export function getH265ProfileSupport(deviceId: number): string {
+    // These are supported by all Cast devices, excluding audio only devices.
+    if (deviceId === deviceIds.ULTRA || deviceId === deviceIds.CCGTV) {
+        return 'high|main|baseline|constrained baseline|high 10';
+    }
+
+    return '';
+}
+
+/**
+ * Get the highest H.265 level supported by the active Cast device.
+ *
+ * @param deviceId - Cast device id.
+ * @returns The highest supported H.265 level.
+ */
+export function getH265LevelSupport(deviceId: number): number {
+    if (deviceId == deviceIds.ULTRA || deviceId == deviceIds.CCGTV) {
+        return 52;
     }
 
     return 0;

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -21,8 +21,10 @@ import {
     hasVP8Support,
     hasVP9Support,
     getMaxWidthSupport,
-    getH26xProfileSupport,
-    getH26xLevelSupport,
+    getH264ProfileSupport,
+    getH264LevelSupport,
+    getH265ProfileSupport,
+    getH265LevelSupport,
     getSupportedVPXVideoCodecs,
     getSupportedMP4VideoCodecs,
     getSupportedMP4AudioCodecs,
@@ -196,10 +198,10 @@ function getCodecProfiles(): Array<CodecProfile> {
     CodecProfiles.push(aacConditions);
 
     const maxWidth: number = getMaxWidthSupport(currentDeviceId);
-    const h26xLevel: number = getH26xLevelSupport(currentDeviceId);
-    const h26xProfile: string = getH26xProfileSupport(currentDeviceId);
+    const h264Level: number = getH264LevelSupport(currentDeviceId);
+    const h264Profile: string = getH264ProfileSupport(currentDeviceId);
 
-    const h26xConditions: CodecProfile = {
+    const h264Conditions: CodecProfile = {
         Codec: 'h264',
         Conditions: [
             createProfileCondition(
@@ -210,12 +212,12 @@ function getCodecProfiles(): Array<CodecProfile> {
             createProfileCondition(
                 ProfileConditionValue.VideoProfile,
                 ProfileConditionType.EqualsAny,
-                h26xProfile
+                h264Profile
             ),
             createProfileCondition(
                 ProfileConditionValue.VideoLevel,
                 ProfileConditionType.LessThanEqual,
-                h26xLevel.toString()
+                h264Level.toString()
             ),
             createProfileCondition(
                 ProfileConditionValue.Width,
@@ -227,7 +229,40 @@ function getCodecProfiles(): Array<CodecProfile> {
         Type: CodecType.Video
     };
 
-    CodecProfiles.push(h26xConditions);
+    CodecProfiles.push(h264Conditions);
+
+    const h265Level: number = getH265LevelSupport(currentDeviceId);
+    const h265Profile: string = getH265ProfileSupport(currentDeviceId);
+
+    const h265Conditions: CodecProfile = {
+        Codec: 'h265',
+        Conditions: [
+            createProfileCondition(
+                ProfileConditionValue.IsAnamorphic,
+                ProfileConditionType.NotEquals,
+                'true'
+            ),
+            createProfileCondition(
+                ProfileConditionValue.VideoProfile,
+                ProfileConditionType.EqualsAny,
+                h265Profile
+            ),
+            createProfileCondition(
+                ProfileConditionValue.VideoLevel,
+                ProfileConditionType.LessThanEqual,
+                h265Level.toString()
+            ),
+            createProfileCondition(
+                ProfileConditionValue.Width,
+                ProfileConditionType.LessThanEqual,
+                maxWidth.toString(),
+                true
+            )
+        ],
+        Type: CodecType.Video
+    };
+
+    CodecProfiles.push(h265Conditions);
 
     const videoConditions: CodecProfile = {
         Conditions: [


### PR DESCRIPTION
The cast devices support different levels for H.264 and H.265. This PR seperates the previous approach of using the same level for both. Previously this caused some H.264 files to not play over HLS as the files were encoded in a level that is not supported.

I'm not entirely sure why it worked well before. It's possible something has changed on the server to more accurately report levels, or that an update was pushed to the cast library that enables stricter checks.