### PR TITLE
Add receiver version to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,7 +35,8 @@ assignees: ''
 
 -   OS: [e.g. Docker, Debian, Windows]
 -   Browser: [e.g. Firefox, Chrome, Safari]
--   Jellyfin Version: [e.g. 10.0.1]
+-   Jellyfin version: [e.g. 10.0.1]
+-   Cast Receiver version: [e.g. Stable, Unstable]
 -   Cast client: [e.g Ultra]
 
 **Additional context**


### PR DESCRIPTION
This will help to identify which issues are related to pre-CAF and post-CAF (especially important before the CAF changes have been pushed to stable)