### PR TITLE
Fix dev server config

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -31,7 +31,7 @@ const common: webpack.Configuration = {
     output: {
         filename: '[name].[fullhash].js',
         path: path.resolve(__dirname, 'dist'),
-        publicPath: './'
+        publicPath: ''
     },
     plugins: [
         // @ts-expect-error - Typings mismatch between versions
@@ -69,11 +69,9 @@ const development: webpack.Configuration = {
     // @ts-expect-error - Typings mismatch between versions
     devServer: {
         compress: true,
-        contentBase: path.join(__dirname, 'dist'),
         port: process.env.RECEIVER_PORT
             ? Number.parseInt(process.env.RECEIVER_PORT, 10)
-            : 9000,
-        publicPath: '/'
+            : 9000
     },
     devtool: 'inline-source-map',
     mode: 'development',


### PR DESCRIPTION
I'm guessing this was broken due to an update to the webpack plugin at some point, but it was erroring out due to options being passed that are no longer valid