### PR TITLE
Fix wrong class name set for app states

### DIFF
--- a/src/types/appStatus.ts
+++ b/src/types/appStatus.ts
@@ -1,10 +1,10 @@
 export enum AppStatus {
-    Audio = 'Audio',
-    Backdrop = 'Backdrop',
-    Details = 'Details',
-    Loading = 'Loading',
-    PlayingWithControls = 'PlayingWithControls',
-    Playing = 'Playing',
+    Audio = 'audio',
+    Backdrop = 'backdrop',
+    Details = 'details',
+    Loading = 'loading',
+    PlayingWithControls = 'playing-with-controls',
+    Playing = 'playing',
     Unset = '',
-    Waiting = 'Waiting'
+    Waiting = 'waiting'
 }


### PR DESCRIPTION
Fixes a regression from #465. The `setAppStatus` function in documentManager sets a class name on body which then shows/hides elements via CSS. The issue was that the enum values were PascalCase but should have been kebab-case.
