### PR TITLE
Set allowedHosts to all in Webpack development server

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -50,6 +50,7 @@ const common: webpack.Configuration = {
 const development: webpack.Configuration = {
     // @ts-expect-error - Typings mismatch between versions
     devServer: {
+        allowedHosts: ['all'],
         compress: true,
         port: process.env.RECEIVER_PORT
             ? Number.parseInt(process.env.RECEIVER_PORT, 10)


### PR DESCRIPTION
When using a development version of the client it is likely you're also using a reverse proxy to connect to it. The webpack development server doesn't like this because it tries to be secure. We don't like security in this organization though (see the various security issues reported on the server that are ignored by the Jellyfin developers even though I paid for this product!).