### PR TITLE
Remove development build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,9 +14,6 @@ jobs:
     build:
         name: Build
         runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                flavor: [development, production]
 
         steps:
             - name: Checkout
@@ -35,25 +32,20 @@ jobs:
                   PACKAGE_JSON=$(jq --indent 4 ".version += \"-$GITHUB_SHA\"" package.json)
                   echo $PACKAGE_JSON > package.json
 
-            - name: Build development
-              if: ${{ matrix.flavor == 'development' }}
-              run: npm run build:development
-
-            - name: Build production
-              if: ${{ matrix.flavor == 'production' }}
-              run: npm run build:production
+            - name: Build
+              run: npm run build
 
             - name: Prepare artifacts
               run: |
                   test -d dist
                   mv dist jellyfin-chromecast
-                  zip -r "jellyfin-chromecast-${{ matrix.flavor }}.zip" "jellyfin-chromecast"
+                  zip -r "jellyfin-chromecast.zip" "jellyfin-chromecast"
 
             - name: Upload artifacts
               uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
               with:
-                  name: jellyfin-chromecast-${{ matrix.flavor }}
-                  path: jellyfin-chromecast-${{ matrix.flavor }}.zip
+                  name: jellyfin-chromecast
+                  path: jellyfin-chromecast.zip
                   if-no-files-found: error
 
     publish:
@@ -61,9 +53,6 @@ jobs:
         runs-on: ubuntu-latest
         if: ${{ contains(github.repository_owner, 'jellyfin') && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}
         needs: [build]
-        strategy:
-            matrix:
-                flavor: [development, production]
 
         steps:
             - name: Set JELLYFIN_VERSION to git tag
@@ -77,7 +66,7 @@ jobs:
             - name: Download artifact
               uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
               with:
-                  name: jellyfin-chromecast-${{ matrix.flavor }}
+                  name: jellyfin-chromecast
 
             - name: Upload release archive to GitHub release
               if: ${{ startsWith(github.ref, 'refs/tags') }}
@@ -85,13 +74,13 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
               with:
-                  asset_paths: '["jellyfin-chromecast-${{ matrix.flavor }}.zip"]'
+                  asset_paths: '["jellyfin-chromecast.zip"]'
 
             - name: Upload release archive to repo.jellyfin.org
               uses: burnett01/rsync-deployments@45d84ad5f6c174f3e0ffc50e9060a9666d09c16e # 6.0.0
               with:
                   switches: -vrptz
-                  path: jellyfin-chromecast-${{ matrix.flavor }}.zip
+                  path: jellyfin-chromecast.zip
                   remote_path: /srv/repository/releases/client/chromecast/versions/${{ env.JELLYFIN_VERSION }}/
                   remote_host: ${{ secrets.DEPLOY_HOST }}
                   remote_user: ${{ secrets.DEPLOY_USER }}
@@ -99,7 +88,6 @@ jobs:
 
             - name: Update repo.jellyfin.org symlinks
               uses: appleboy/ssh-action@55dabf81b49d4120609345970c91507e2d734799 # v1.0.0
-              if: ${{ matrix.flavor == 'production' }}
               with:
                   host: ${{ secrets.DEPLOY_HOST }}
                   username: ${{ secrets.DEPLOY_USER }}
@@ -109,7 +97,7 @@ jobs:
                   script: |
                       cd /srv/repository/releases/client/chromecast;
                       rm -rf *.zip;
-                      ln -s versions/${JELLYFIN_VERSION}/jellyfin-chromecast-${{ matrix.flavor }}-${JELLYFIN_VERSION}.zip .;
+                      ln -s versions/${JELLYFIN_VERSION}/jellyfin-chromecast-${JELLYFIN_VERSION}.zip .;
 
     deploy:
         name: Deploy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,9 @@ The development environment is setup with editorconfig. Code style is enforced b
 
 ### Building/Using
 
-`npm run build:development` - Build a development version
-
 `npm start` - Build a development version and start a dev server
 
-`npm run build:production` - Build a production version
+`npm run build` - Build a production version
 
 `npm run test` - Run tests
 
@@ -33,7 +31,7 @@ The development environment is setup with editorconfig. Code style is enforced b
 3. Change `applicationStable` and `applicationUnstable` in `jellyfin-web/src/plugins/chromecastPlayer/plugin.js` to your own application ID.
 4. Run the local copy of jellyfin-web using the provided instructions in the repo.
 5. Clone this repo and run `npm install`. This will install all dependencies, run tests and build a production build by default.
-6. Make changes and build with `npm run build:development`. `build:development` includes sourcemaps that'll make it easier to debug.
+6. Make changes and build with `npm run build`.
 7. Before pushing your changes, make sure to run `npm run test` and `npm run lint`.
 
 > NOTE: It is recommended to symlink the `dist` folder pointing to a location on your web server hosting the files. That way you can refresh the cast receiver via the Chrome Remote Debugger and see your changes without having to manually copy after each build.

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
         "url": "git+https://github.com/jellyfin/jellyfin-chromecast.git"
     },
     "scripts": {
-        "build:development": "cross-env TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack --config webpack.config.ts --mode=development",
-        "build:production": "cross-env TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack --config webpack.config.ts --mode=production",
+        "build": "cross-env TS_NODE_PROJECT=\"tsconfig-webpack.json\" webpack --config webpack.config.ts --mode=production",
         "lint": "npm run lint:code && npm run lint:css && npm run prettier",
         "lint:code": "eslint --ext .ts,.js,.json .",
         "lint:css": "stylelint **/*.css",


### PR DESCRIPTION
This one simplifies the build (specifically CI) by removing the development build. If you want dev you use `npm run start`, if you want a build you use `npm run build` and get a production build.

Requirement for #476 

_🤞 this doesn't break CI again_