### PR TITLE
Fix base in Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { version } from './package.json';
 
 export default defineConfig({
     root: 'src',
+    base: './',
     build: {
         outDir: '../dist',
         emptyOutDir: true,


### PR DESCRIPTION
The deployment to apps1.jellyfin.org uses a subdirectory. Vite by default uses `/` as base so the deployments after #476 do not work. This PR solves that issue.