### PR TITLE
Fix sync of volume level with webclient

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -55,7 +55,7 @@ export function getReportingParams(state: PlaybackState): PlaybackProgressInfo {
         PositionTicks: Math.round(getCurrentPositionTicks(state)),
         RepeatMode: window.repeatMode,
         SubtitleStreamIndex: state.subtitleStreamIndex,
-        VolumeLevel: Math.round(window.volume?.level ?? 0 * 100)
+        VolumeLevel: Math.round((window.volume?.level ?? 0) * 100)
     };
 }
 


### PR DESCRIPTION
The volume level slider of the jellyfin webclient is not synchronized with the chromecast webreceiver volume setting.
This is fixed here.

**Changes**
Add appropriate parentheses.