### PR TITLE
Expand readme (inspired by server-repo)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,17 @@ The development environment is setup with editorconfig. Code style is enforced b
 `npm run lint` - Run linting and prettier
 
 1. Register a new [application](https://developers.google.com/cast/docs/registration). It is important that you choose a "Custom application", the rest of the details are up to you (name, description, etc). You will need a web server to host the files on.
-2. Set up a local copy of [jellyfin-web](https://github.com/jellyfin/jellyfin-web).
-3. Change `applicationStable` and `applicationUnstable` in `jellyfin-web/src/plugins/chromecastPlayer/plugin.js` to your own application ID.
-4. Run the local copy of jellyfin-web using the provided instructions in the repo.
+
+2.  Ensure that you can use this app:
+    #### For versions 10.8.x and earlier:
+    - Set up a local copy of [jellyfin-web](https://github.com/jellyfin/jellyfin-web).
+    - Change `applicationStable` and `applicationUnstable` in `jellyfin-web/src/plugins/chromecastPlayer/plugin.js` to your own application ID.
+    - Run the local copy of jellyfin-web using the provided instructions in the repo.
+    
+    #### For versions 10.9.x and beyond:
+    - Add your `CastReceiverApplication` `ID` and `Name` to the jellyfin `system.xml` in the `configuration` folder.
+    - Your custom hosted application is now available to select next to `stable` and `unstable`. From the client of your choice.
+
 5. Clone this repo and run `npm install`. This will install all dependencies, run tests and build a production build by default.
 6. Make changes and build with `npm run build`.
 7. Before pushing your changes, make sure to run `npm run test` and `npm run lint`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Jellyfin Chromecast Client</h1>
+<h1 align="center">Jellyfin Chromecast Web Receiver</h1>
 <h3 align="center">Part of the <a href="https://jellyfin.org">Jellyfin Project</a></h3>
 
 <p align="center">
@@ -13,25 +13,34 @@
 </a>
 </p>
 
-Jellyfin chromecast is a receiver used when casting to a google cast capable device. It is automatically used when casting from the jellyfin android client or jellyfin web client.
+Jellyfin Chromecast is a receiver app used when casting to a Google Cast capable device. It is used when casting from the Jellyfin Android client or Jellyfin web client.
+
+### How do I use it?
+
+A `stable` and `unstable` version of this app are already included in `jellyfin-server`. There is no need to seperately install this project. To host your own version (for developing) see `CONTRIBUTING.md`.
 
 ### What does it do?
 
-As soon as you push the "cast" button on your client this application will start on you cast-capable device & handle it from there.
+This is a `web receiver` as defined in the [Google Chromecast architecture](https://developers.google.com/cast/docs/overview).
+
+As soon as you push the "cast" button on your client this application will start on you cast-capable device & handle it from there. 
 
 ### What doesn't it do?
 
-Anything related to your non-cast device (e.g. your phone, browser, other device). Any issues/features related to that: check the respective repository.
+Anything related to your non-cast device (e.g. your phone, browser, other device) or anything about the inclusion of casting for a specific client (e.g. casting from the iOS app).
+
+Any issues/features related to that: check the respective repository.
 
 ### Something not working right?
-First check if the issue is actually google-cast related. So answer the question:
+First check if the issue is actually Google Cast related. So answer the question:
 
-`"Can I reproduce the issue on any other device than a google chromecast?"`
+`"Can I reproduce the issue on any other device than a Google Chromecast?"`
 
-If yes: Then the issue probably lies somewhere else. If no: Open an <a href="https://github.com/jellyfin/jellyfin-chromecast/issues/new/choose">Issue</a> on GitHub.<br/>
+If yes: The issue probably lies somewhere else. 
+If no: Open an <a href="https://github.com/jellyfin/jellyfin-chromecast/issues/new/choose">Issue</a> on GitHub.<br/>
 
 ### Testing
 
-Jellyfin allows switching between a `stable` and `unstable` version of the client. Go the client of your choice and: `user` -> `settings` -> `playback` -> `Google cast version`.
+Jellyfin allows switching between a `stable` and `unstable` version of the client. Go the client of your choice and: `user` -> `settings` -> `playback` -> `Google Cast version`.
 
 Note that this setting is set per-user.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
-# Jellyfin Chromecast
+<h1 align="center">Jellyfin Chromecast Client</h1>
+<h3 align="center">Part of the <a href="https://jellyfin.org">Jellyfin Project</a></h3>
 
-Source code for the Jellyfin Chromecast receiver application
+<p align="center">
+<img alt="Logo Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true"/>
+<br/>
+<br/>
+<a href="https://github.com/jellyfin/jellyfin">
+<img alt="GPL 2.0 License" src="https://img.shields.io/github/license/jellyfin/jellyfin-chromecast.svg"/>
+</a>
+<a href="https://github.com/jellyfin/jellyfin/releases">
+<img alt="Current Release" src="https://img.shields.io/github/release/jellyfin/jellyfin-chromecast.svg"/>
+</a>
+</p>
+
+Jellyfin chromecast is a receiver used when casting to a google cast capable device. It is automatically used when casting from the jellyfin android client or jellyfin web client.
+
+### What does it do?
+
+As soon as you push the "cast" button on your client this application will start on you cast-capable device & handle it from there.
+
+### What doesn't it do?
+
+Anything related to your non-cast device (e.g. your phone, browser, other device). Any issues/features related to that: check the respective repository.
+
+### Something not working right?
+First check if the issue is actually google-cast related. So answer the question:
+
+`"Can I reproduce the issue on any other device than a google chromecast?"`
+
+If yes: Then the issue probably lies somewhere else. If no: Open an <a href="https://github.com/jellyfin/jellyfin-chromecast/issues/new/choose">Issue</a> on GitHub.<br/>
+
+### Testing
+
+Jellyfin allows switching between a `stable` and `unstable` version of the client. Go the client of your choice and: `user` -> `settings` -> `playback` -> `Google cast version`.
+
+Note that this setting is set per-user.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-<h1 align="center">Jellyfin Chromecast Web Receiver</h1>
+<h1 align="center">Jellyfin Cast Web Receiver</h1>
 <h3 align="center">Part of the <a href="https://jellyfin.org">Jellyfin Project</a></h3>
 
 <p align="center">
 <img alt="Logo Banner" src="https://raw.githubusercontent.com/jellyfin/jellyfin-ux/master/branding/SVG/banner-logo-solid.svg?sanitize=true"/>
 <br/>
 <br/>
-<a href="https://github.com/jellyfin/jellyfin">
+<a href="https://github.com/jellyfin/jellyfin-chromecast">
 <img alt="GPL 2.0 License" src="https://img.shields.io/github/license/jellyfin/jellyfin-chromecast.svg"/>
 </a>
-<a href="https://github.com/jellyfin/jellyfin/releases">
+<a href="https://github.com/jellyfin/jellyfin-chromecast/releases">
 <img alt="Current Release" src="https://img.shields.io/github/release/jellyfin/jellyfin-chromecast.svg"/>
 </a>
 </p>
 
-Jellyfin Chromecast is a receiver app used when casting to a Google Cast capable device. It is used when casting from the Jellyfin Android client or Jellyfin web client.
+The Jellyfin Cast Web Receiver is the frontend used when casting to a Google Cast capable device. It is used by default when casting from the Jellyfin Android app or Jellyfin web client.
 
 ### How do I use it?
 
-A `stable` and `unstable` version of this app are already included in `jellyfin-server`. There is no need to seperately install this project. To host your own version (for developing) see `CONTRIBUTING.md`.
+A `stable` and `unstable` version of this app are already included in the Jellyfin server. There is no need to separately install this project. To host your own version (for developing) see `CONTRIBUTING.md`.
 
 ### What does it do?
 
-This is a `web receiver` as defined in the [Google Chromecast architecture](https://developers.google.com/cast/docs/overview).
+This is a `web receiver` as defined in the [Google Cast architecture](https://developers.google.com/cast/docs/overview).
 
-As soon as you push the "cast" button on your client this application will start on you cast-capable device & handle it from there. 
+As soon as you press the "cast" button on your client this application will start on you cast-capable device and handle playback functionality. 
 
 ### What doesn't it do?
 
@@ -32,12 +32,13 @@ Anything related to your non-cast device (e.g. your phone, browser, other device
 Any issues/features related to that: check the respective repository.
 
 ### Something not working right?
+
 First check if the issue is actually Google Cast related. So answer the question:
 
-`"Can I reproduce the issue on any other device than a Google Chromecast?"`
+`"Can I reproduce the issue on any other way then when casting to a Google Cast capable device?"`
 
 If yes: The issue probably lies somewhere else. 
-If no: Open an <a href="https://github.com/jellyfin/jellyfin-chromecast/issues/new/choose">Issue</a> on GitHub.<br/>
+If no: [Open an issue on GitHub](https://github.com/jellyfin/jellyfin-chromecast/issues/new/choose).
 
 ### Testing
 


### PR DESCRIPTION
A set-up for a more complete README. I did notice some oddities while writing it though:

- Current `latest` version is 1.0.1 however there is also a version 1.1.0 version available which seems odd. Is this a mistake? (I do think 1.0.1 is newer, but the number is off. Would assume it to be 1.1.1 or 1.2.0).
- The bit about `testing`: We can switch between a stable & unstable version. But no where can I actually find an actual implementation of something that does something with this setting.  The jellyfin-web client seems to use it's own chromecast plugin. So is this repo even used a.t.m.? (if so: can you point me to the right direction so I can figure out stuff further from there?).
