### PR TITLE
Use Shaka Player for HLS playback

### DIFF
--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -925,6 +925,7 @@ if (!import.meta.env.PROD) {
     window.castReceiverContext.setLoggerLevel(cast.framework.LoggerLevel.NONE);
 }
 
+options.useShakaForHls = true;
 options.playbackConfig = new cast.framework.PlaybackConfig();
 // Set the player to start playback as soon as there are five seconds of
 // media content buffered. Default is 10.


### PR DESCRIPTION
Media Player Library is currently used for HLS playback but is no longer receiving critical updates. This PR opts in to using the Shaka Player for HLS playback.

From https://developers.google.com/cast/docs/web_receiver/shaka_migration:
> We recommend you to opt in to use Shaka Player for your application's HLS content playback.

In testing (on a Chromecast 2nd gen) Shaka Player seems to be much more reliable than MPL. MPL buffering tends to cause major playback issues and does not recover in most instances, while Shaka can recover gracefully and continue playback.

According to [the published timeline](https://developers.google.com/cast/docs/web_receiver/shaka_migration#timeline) Shaka Player will become the default in H2 '24 in any case. This PR brings that forward and hopefully improves the experience for other users in the meantime.