### PR TITLE
Turn on isolatedModules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "resolveJsonModule": true,
         "allowSyntheticDefaultImports": true,
         "allowJs": true,
+        "isolatedModules": true,
         "sourceMap": true,
         "outDir": "./dist/",
         "strict": true,


### PR DESCRIPTION
This should be enabled for Vite since its build process uses esbuild for transpilation without type information. This option enables warnings when using features that don't work for isolated transpilation.

https://v4.vitejs.dev/guide/features.html#typescript-compiler-options