### PR TITLE
Enable bundler module resolution mode

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "target": "ES2015",
         "module": "ESNext",
-        "moduleResolution": "Node",
+        "moduleResolution": "bundler",
         "lib": ["dom", "ES2015"],
         "resolveJsonModule": true,
         "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Previous "node" option should no longer be used:
https://www.typescriptlang.org/docs/handbook/modules/reference.html#node10-formerly-known-as-node

"bundler" is recommended when using a bundler.