### PR TITLE
Enable ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "jellyfin-chromecast",
     "description": "Cast receiver for Jellyfin",
     "version": "3.0.0",
+    "type": "module",
     "bugs": {
         "url": "https://github.com/jellyfin/jellyfin-chromecast/issues"
     },


### PR DESCRIPTION
Addresses Vite's CJS deprecation.

https://v4.vite.dev/guide/migration.html#deprecate-cjs-node-api