### PR TITLE
Fix issues found by TypeScript compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
             },
             "devDependencies": {
                 "@types/chromecast-caf-receiver": "6.0.17",
+                "@types/node": "^18.19.57",
                 "eslint": "9.13.0",
                 "eslint-config-prettier": "9.1.0",
                 "eslint-import-resolver-typescript": "3.6.3",
@@ -1291,12 +1292,14 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.17.19",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.19.tgz",
-            "integrity": "sha512-+pMhShR3Or5GR0/sp4Da7FnhVmTalWm81M6MkEldbwjETSaPalw138Z4KdpQaistvqQxLB7Cy4xwYdxpbSOs9Q==",
+            "version": "18.19.57",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.57.tgz",
+            "integrity": "sha512-I2ioBd/IPrYDMv9UNR5NlPElOZ68QB7yY5V2EsLtSrTO0LM0PnCEFF9biLWHf5k+sIy4ohueCV9t4gk1AEdlVA==",
             "dev": true,
-            "optional": true,
-            "peer": true
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.9.0",
@@ -5552,6 +5555,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     },
     "devDependencies": {
         "@types/chromecast-caf-receiver": "6.0.17",
+        "@types/node": "^18.19.57",
         "eslint": "9.13.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-import-resolver-typescript": "3.6.3",

--- a/src/components/documentManager.ts
+++ b/src/components/documentManager.ts
@@ -8,7 +8,7 @@ export abstract class DocumentManager {
     // Duration between each backdrop switch in ms
     private static backdropPeriodMs: number | null = 30000;
     // Timer state - so that we don't start the interval more than necessary
-    private static backdropTimer: NodeJS.Timer | null = null;
+    private static backdropTimer: number | null = null;
 
     private static status = AppStatus.Unset;
 
@@ -415,7 +415,7 @@ export abstract class DocumentManager {
             return;
         }
 
-        this.backdropTimer = setInterval(
+        this.backdropTimer = window.setInterval(
             () => DocumentManager.setRandomUserBackdrop(),
             this.backdropPeriodMs
         );


### PR DESCRIPTION
I think ideally TS wouldn't import the Node types at all, so `setInterval` wouldn't need the explicit `window` to ensure it's using the DOM `setInterval` and not Node's, but I'm not clear on how to achieve that.

In the meantime this, along with #627, will allow a clean run of `tsc`.