### PR TITLE
Start using generated Typescript API for API calls

### DIFF
--- a/src/components/jellyfinActions.ts
+++ b/src/components/jellyfinActions.ts
@@ -2,8 +2,8 @@ import type {
     BaseItemDto,
     DeviceProfile,
     LiveStreamResponse,
-    MediaInfoApiGetPostedPlaybackInfoRequest,
     MediaSourceInfo,
+    PlaybackInfoDto,
     PlaybackProgressInfo,
     PlayRequest
 } from '@jellyfin/sdk/lib/generated-client';
@@ -260,20 +260,34 @@ export async function getPlaybackInfo(
         return Promise.reject('Item ID not available.');
     }
 
-    const query: MediaInfoApiGetPostedPlaybackInfoRequest = {
-        audioStreamIndex: audioStreamIndex ?? undefined,
-        itemId: item.Id,
-        liveStreamId: liveStreamId ?? undefined,
-        maxStreamingBitrate: maxBitrate,
-        mediaSourceId: mediaSourceId ?? undefined,
-        startTimeTicks: startPosition || 0,
-        subtitleStreamIndex: subtitleStreamIndex ?? undefined,
-        userId: JellyfinApi.userId ?? undefined
+    const query: PlaybackInfoDto = {
+        MaxStreamingBitrate: maxBitrate,
+        StartTimeTicks: startPosition || 0,
+        UserId: JellyfinApi.userId
     };
+
+    if (audioStreamIndex != null) {
+        query.AudioStreamIndex = audioStreamIndex;
+    }
+
+    if (subtitleStreamIndex != null) {
+        query.SubtitleStreamIndex = subtitleStreamIndex;
+    }
+
+    if (mediaSourceId) {
+        query.MediaSourceId = mediaSourceId;
+    }
+
+    if (liveStreamId) {
+        query.LiveStreamId = liveStreamId;
+    }
 
     const response = await getMediaInfoApi(
         JellyfinApi.jellyfinApi
-    ).getPostedPlaybackInfo(query);
+    ).getPostedPlaybackInfo({
+        itemId: item.Id,
+        playbackInfoDto: query
+    });
 
     return response.data;
 }

--- a/src/components/jellyfinActions.ts
+++ b/src/components/jellyfinActions.ts
@@ -6,6 +6,7 @@ import type {
     PlaybackProgressInfo,
     PlayRequest
 } from '@jellyfin/sdk/lib/generated-client';
+import { getPlaystateApi } from '@jellyfin/sdk/lib/utils/api';
 import { getSenderReportingData, broadcastToMessageBus } from '../helpers';
 import { AppStatus } from '../types/appStatus';
 import { JellyfinApi } from './jellyfinApi';
@@ -91,7 +92,7 @@ export function reportPlaybackStart(
  * @param broadcastEventName - name of event to send to the cast sender
  * @returns Promise for the http request
  */
-export function reportPlaybackProgress(
+export async function reportPlaybackProgress(
     state: PlaybackState,
     reportingParams: PlaybackProgressInfo,
     reportToServer = true,
@@ -109,10 +110,8 @@ export function reportPlaybackProgress(
     restartPingInterval(reportingParams);
     lastTranscoderPing = new Date().getTime();
 
-    return JellyfinApi.authAjax('Sessions/Playing/Progress', {
-        contentType: 'application/json',
-        data: JSON.stringify(reportingParams),
-        type: 'POST'
+    await getPlaystateApi(JellyfinApi.jellyfinApi).reportPlaybackProgress({
+        playbackProgressInfo: reportingParams
     });
 }
 

--- a/src/components/jellyfinActions.ts
+++ b/src/components/jellyfinActions.ts
@@ -59,7 +59,7 @@ export function stopPingInterval(): void {
  * @param reportingParams - parameters to send to the server
  * @returns promise to wait for the request
  */
-export function reportPlaybackStart(
+export async function reportPlaybackStart(
     state: PlaybackState,
     reportingParams: PlaybackProgressInfo
 ): Promise<void> {
@@ -77,10 +77,8 @@ export function reportPlaybackStart(
 
     restartPingInterval(reportingParams);
 
-    return JellyfinApi.authAjax('Sessions/Playing', {
-        contentType: 'application/json',
-        data: JSON.stringify(reportingParams),
-        type: 'POST'
+    await getPlaystateApi(JellyfinApi.jellyfinApi).reportPlaybackStart({
+        playbackStartInfo: reportingParams
     });
 }
 

--- a/src/components/jellyfinActions.ts
+++ b/src/components/jellyfinActions.ts
@@ -237,6 +237,7 @@ export function play(state: PlaybackState): void {
  * get PlaybackInfo
  * @param item - item
  * @param maxBitrate - maxBitrate
+ * @param deviceProfile - deviceProfile
  * @param startPosition - startPosition
  * @param mediaSourceId - mediaSourceId
  * @param audioStreamIndex - audioStreamIndex
@@ -247,6 +248,7 @@ export function play(state: PlaybackState): void {
 export async function getPlaybackInfo(
     item: BaseItemDto,
     maxBitrate: number,
+    deviceProfile: DeviceProfile,
     startPosition: number,
     mediaSourceId: string,
     audioStreamIndex: number,
@@ -261,6 +263,7 @@ export async function getPlaybackInfo(
     }
 
     const query: PlaybackInfoDto = {
+        DeviceProfile: deviceProfile,
         MaxStreamingBitrate: maxBitrate,
         StartTimeTicks: startPosition || 0,
         UserId: JellyfinApi.userId

--- a/src/components/jellyfinApi.ts
+++ b/src/components/jellyfinApi.ts
@@ -18,12 +18,22 @@ export abstract class JellyfinApi {
     // unique id
     public static deviceId = '';
 
+    // Jellyfin SDK
+    private static jellyfinSdk: Jellyfin | undefined;
+
+    // Jellyfin API
+    public static jellyfinApi: Api;
+
     public static setServerInfo(
         userId?: string,
         accessToken?: string,
         serverAddress?: string,
         receiverName = ''
     ): void {
+        const regenApi =
+            this.accessToken !== accessToken ||
+            this.serverAddress !== serverAddress;
+
         console.debug(
             `JellyfinApi.setServerInfo: user:${userId}, token:${accessToken}, server:${serverAddress}, name:${receiverName}`
         );
@@ -47,6 +57,32 @@ export abstract class JellyfinApi {
                 senders.length !== 0 && senders[0].id
                     ? senders[0].id
                     : new Date().getTime().toString();
+        }
+
+        if (!this.jellyfinSdk) {
+            this.jellyfinSdk = new Jellyfin({
+                clientInfo: {
+                    name: 'Chromecast',
+                    version: packageVersion
+                },
+                deviceInfo: {
+                    id: this.deviceId,
+                    name: this.deviceName
+                }
+            });
+        }
+
+        if (!this.jellyfinApi || regenApi) {
+            if (serverAddress && accessToken) {
+                this.jellyfinApi = this.jellyfinSdk.createApi(
+                    serverAddress,
+                    accessToken
+                );
+            } else {
+                console.error(
+                    'Server address or access token not provided - could not create instance of Jellyfin API'
+                );
+            }
         }
     }
 

--- a/src/components/jellyfinApi.ts
+++ b/src/components/jellyfinApi.ts
@@ -1,5 +1,28 @@
+import { Api, Jellyfin } from '@jellyfin/sdk';
+import axios from 'axios';
 import { version as packageVersion } from '../../package.json';
 import { ajax } from './fetchhelper';
+
+axios.interceptors.request.use((request) => {
+    console.log(`requesting url: ${request.url}`);
+
+    return request;
+});
+
+axios.interceptors.response.use(
+    (response) => {
+        console.log(
+            `response status: ${response.status}, url: ${response.request.responseURL}`
+        );
+
+        return response;
+    },
+    // eslint-disable-next-line promise/prefer-await-to-callbacks
+    (error) => {
+        console.log(`request failed to url: ${error.request.url}`);
+        throw error;
+    }
+);
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export abstract class JellyfinApi {

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -206,7 +206,6 @@ export abstract class PlaybackManager {
         const playbackInfo = await getPlaybackInfo(
             item,
             maxBitrate,
-            deviceProfile,
             options.startPositionTicks,
             options.mediaSourceId,
             options.audioStreamIndex,

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -206,6 +206,7 @@ export abstract class PlaybackManager {
         const playbackInfo = await getPlaybackInfo(
             item,
             maxBitrate,
+            deviceProfile,
             options.startPositionTicks,
             options.mediaSourceId,
             options.audioStreamIndex,


### PR DESCRIPTION
This PR:
* Sets up the SDK & API instances
* Converts three playback actions to use the generated API instead of a fetch helper

I wanted to see if this initial implementation was acceptable before continuing.

Tested successfully locally.