### PR TITLE
Enable no-unnecessary-type-assertion ts eslint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,6 +59,7 @@ export default [
         rules: {
             '@typescript-eslint/explicit-function-return-type': 'error',
             '@typescript-eslint/no-explicit-any': 'warn',
+            '@typescript-eslint/no-unnecessary-type-assertion': 'error',
             '@typescript-eslint/no-unused-expressions': 'warn',
             '@typescript-eslint/no-unused-vars': 'error',
             '@typescript-eslint/prefer-ts-expect-error': 'error',

--- a/src/components/documentManager.ts
+++ b/src/components/documentManager.ts
@@ -581,9 +581,9 @@ export abstract class DocumentManager {
         const element = this.querySelector('.detailImageProgressContainer');
 
         if (value) {
-            (element as HTMLElement).classList.remove('d-none');
+            element.classList.remove('d-none');
         } else {
-            (element as HTMLElement).classList.add('d-none');
+            element.classList.add('d-none');
         }
     }
 


### PR DESCRIPTION
This is enabled by default in the recommended type checked rule set.