### PR TITLE
Request mp4 container when transcoding HLS video

### DIFF
--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -291,7 +291,7 @@ function getTranscodingProfiles(): TranscodingProfile[] {
     const hlsAudioCodecs = getSupportedHLSAudioCodecs();
     const audioChannels: number = hasSurroundSupport() ? 6 : 2;
 
-    if (profileOptions.enableHls !== false) {
+    if (profileOptions.enableHls) {
         TranscodingProfiles.push({
             AudioCodec: hlsAudioCodecs.join(','),
             BreakOnNonKeyFrames: false,
@@ -328,7 +328,7 @@ function getTranscodingProfiles(): TranscodingProfile[] {
     if (
         hlsVideoCodecs.length &&
         hlsAudioCodecs.length &&
-        profileOptions.enableHls !== false
+        profileOptions.enableHls
     ) {
         TranscodingProfiles.push({
             AudioCodec: hlsAudioCodecs.join(','),

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -333,7 +333,7 @@ function getTranscodingProfiles(): TranscodingProfile[] {
         TranscodingProfiles.push({
             AudioCodec: hlsAudioCodecs.join(','),
             BreakOnNonKeyFrames: false,
-            Container: 'ts',
+            Container: 'mp4',
             Context: EncodingContext.Streaming,
             MaxAudioChannels: audioChannels.toString(),
             MinSegments: 1,


### PR DESCRIPTION
Shaka player 4.8 and up always remuxes TS to MP4, while the Jellyfin Cast client always requests a TS container. This means any transcoded MP4 stream will be remuxed to TS on the server then remuxed again on the device.

As Cast clients (particularly older ones) are low-powered devices, it's important to reduce load on the device when possible. It also avoids unnecessary remuxing on the server in some scenarios.

In local testing the Shaka player version is 4.3.4 but this will be updated automatically to 4.9.2 in future. This change is still useful for earlier Shaka player versions since TS remuxing was identified as a problem area anyway, so using MP4 should improve streaming reliablity to Cast devices regardless of the Shaka version.