### PR TITLE
Don't limit max width for h264 streams to the window width

### DIFF
--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -93,23 +93,9 @@ export function getMaxBitrateSupport(): number {
 /**
  * Get the max supported video width the active Cast device supports.
  * @param deviceId - Cast device id.
- * @param codec - Video codec.
  * @returns Max supported width.
  */
-export function getMaxWidthSupport(
-    deviceId: DeviceIds,
-    codec?: string
-): number {
-    if (codec === 'h264') {
-        // with HLS, it will produce a manifest error if we
-        // send any stream larger than the screen size...
-        return window.innerWidth;
-    }
-
-    // mkv playback can use the device limitations.
-    // The devices are capable of decoding and downscaling,
-    // they just refuse to do it with HLS. This increases
-    // the rate of direct playback.
+export function getMaxWidthSupport(deviceId: DeviceIds): number {
     switch (deviceId) {
         case DeviceIds.ULTRA:
         case DeviceIds.CCGTV:

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -206,7 +206,7 @@ function getCodecProfiles(): CodecProfile[] {
             createProfileCondition(
                 ProfileConditionValue.Width,
                 ProfileConditionType.LessThanEqual,
-                getMaxWidthSupport(currentDeviceId, 'h264').toString(),
+                getMaxWidthSupport(currentDeviceId).toString(),
                 true
             )
         ],


### PR DESCRIPTION
Cast devices variously support video max widths of 1280, 1920 and 3840. `window.innerWidth` returns the max width of the receiver page which is not the same resolution and limits h264 streams to a max of 720p on most devices.