### PR TITLE
Report playback stopped when media finishes

### DIFF
--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -12,7 +12,8 @@ import {
     getInstantMixItems,
     translateRequestedItems,
     broadcastToMessageBus,
-    ticksToSeconds
+    ticksToSeconds,
+    TicksPerSecond
 } from '../helpers';
 import {
     reportPlaybackStart,
@@ -153,11 +154,7 @@ export function disableTimeUpdateListener(): void {
 enableTimeUpdateListener();
 
 window.addEventListener('beforeunload', () => {
-    // Try to cleanup after ourselves before the page closes
-    const playbackState = PlaybackManager.playbackState;
-
     disableTimeUpdateListener();
-    reportPlaybackStopped(playbackState, getReportingParams(playbackState));
 });
 
 window.playerManager.addEventListener(
@@ -194,8 +191,20 @@ function defaultOnStop(): void {
 
 window.playerManager.addEventListener(
     cast.framework.events.EventType.MEDIA_FINISHED,
-    defaultOnStop
+    (mediaFinishedEvent): void => {
+        const playbackState = PlaybackManager.playbackState;
+
+        reportPlaybackStopped(playbackState, {
+            ...getReportingParams(playbackState),
+            PositionTicks:
+                (mediaFinishedEvent.currentMediaTime ??
+                    getCurrentPositionTicks(playbackState)) * TicksPerSecond
+        });
+
+        defaultOnStop();
+    }
 );
+
 window.playerManager.addEventListener(
     cast.framework.events.EventType.ABORT,
     defaultOnStop
@@ -211,7 +220,6 @@ window.playerManager.addEventListener(
             return;
         }
 
-        reportPlaybackStopped(playbackState, getReportingParams(playbackState));
         PlaybackManager.resetPlaybackScope();
 
         if (!PlaybackManager.playNextItem()) {
@@ -226,16 +234,6 @@ window.playerManager.addEventListener(
     cast.framework.events.EventType.PLAYING,
     (): void => {
         reportPlaybackStart(
-            PlaybackManager.playbackState,
-            getReportingParams(PlaybackManager.playbackState)
-        );
-    }
-);
-// Notify of playback end just before stopping it, to get a good tick position
-window.playerManager.addEventListener(
-    cast.framework.events.EventType.REQUEST_STOP,
-    (): void => {
-        reportPlaybackStopped(
             PlaybackManager.playbackState,
             getReportingParams(PlaybackManager.playbackState)
         );

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -194,7 +194,6 @@ export abstract class PlaybackManager {
         item: BaseItemDto,
         options: any // eslint-disable-line @typescript-eslint/no-explicit-any
     ): Promise<void> {
-        this.playbackState.isChangingStream = false;
         DocumentManager.setAppStatus(AppStatus.Loading);
 
         const maxBitrate = await getMaxBitrate();
@@ -286,7 +285,10 @@ export abstract class PlaybackManager {
             loadRequestData.currentTime = ticksToSeconds(startPositionTicks);
         }
 
+        const isChangingStream = this.playbackState.isChangingStream;
+
         load(mediaInfo.customData, item);
+        this.playbackState.isChangingStream = isChangingStream;
         this.playerManager.load(loadRequestData);
 
         this.playbackState.PlaybackMediaSource = mediaSource;


### PR DESCRIPTION
This consolidates the logic for reporting stopped playback to the server so it is only reported when MEDIA_FINISHED event is fired. In addition, the current position reported to the server will be the current time reported by the Cast player which will be the most accurate representation. If this is not available, it will fall back to the existing logic of checking the current playback position from the receiver's playback state.

This PR also fixes an issue that occurs when changing audio or subtitle streams. The Cast view would show the "waiting" view after a request to change subtitle or audio streams. Now, the player remains visible when changing streams.