### PR TITLE
Migrate stopping active encodings to jellyfin-sdk-typescript

### DIFF
--- a/src/components/jellyfinActions.ts
+++ b/src/components/jellyfinActions.ts
@@ -7,7 +7,11 @@ import type {
     PlaybackProgressInfo,
     PlayRequest
 } from '@jellyfin/sdk/lib/generated-client';
-import { getMediaInfoApi, getPlaystateApi } from '@jellyfin/sdk/lib/utils/api';
+import {
+    getHlsSegmentApi,
+    getMediaInfoApi,
+    getPlaystateApi
+} from '@jellyfin/sdk/lib/utils/api';
 import { getSenderReportingData, broadcastToMessageBus } from '../helpers';
 import { AppStatus } from '../types/appStatus';
 import { JellyfinApi } from './jellyfinApi';
@@ -400,21 +404,14 @@ export async function detectBitrate(numBytes = 500000): Promise<number> {
 
 /**
  * Tell Jellyfin to kill off our active transcoding session
- * @param state - playback state.
+ * @param playSessionId - the play session ID to stop encoding
  * @returns Promise for the http request to go through
  */
-export function stopActiveEncodings(state: PlaybackState): Promise<void> {
-    const options = {
+export async function stopActiveEncodings(
+    playSessionId: string
+): Promise<void> {
+    await getHlsSegmentApi(JellyfinApi.jellyfinApi).stopEncodingProcess({
         deviceId: JellyfinApi.deviceId,
-        PlaySessionId: ''
-    };
-
-    if (state.playSessionId) {
-        options.PlaySessionId = state.playSessionId;
-    }
-
-    return JellyfinApi.authAjax('Videos/ActiveEncodings', {
-        query: options,
-        type: 'DELETE'
+        playSessionId: playSessionId
     });
 }


### PR DESCRIPTION
This function is currently unused so there were no call sites to fix.

Removing this unused function is an option but there's an open TODO item here:

https://github.com/jellyfin/jellyfin-chromecast/blob/2990a569df4bcf2a2dd0587376211babff65343b/src/components/maincontroller.ts#L507-L517

So I thought it was best to leave it in case that's ever addressed.