### PR TITLE
Stop sending QueueableMediaTypes to cast sender

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -99,8 +99,7 @@ export function getSenderReportingData(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const state: any = {
         ItemId: reportingData.ItemId,
-        PlayState: reportingData,
-        QueueableMediaTypes: ['Audio', 'Video']
+        PlayState: reportingData
     };
 
     state.NowPlayingItem = {


### PR DESCRIPTION
This property is not used by the jellyfin-web Cast sender.