### PR TITLE
Use `AudioContext` to test audio channels count

### DIFF
--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -31,17 +31,14 @@ export function hasAC3Support(): boolean {
 }
 
 /**
- * Checks if the device can play any surround codecs.
- *
- * Potentially, we could guess that systems with E-AC-3 or AC-3
- * will mostly support 6ch pcm, and if any generation of cast devices
- * is actually capable of decoding e.g. aac 6ch, we can return true here
- * and give it a shot.
- * @returns true if surround codecs can be played
+ * Checks for the number of audio channels supported on the device.
+ * @returns The maximum number of audio channels supported.
  */
-export function hasSurroundSupport(): boolean {
-    // This will turn on surround support if passthrough is available.
-    return hasAC3Support();
+export function getMaxAudioChannels(): number {
+    const audioCtx = new window.AudioContext();
+
+    // Make sure we allow at least 1 channel, in case of some bad output.
+    return Math.max(audioCtx.destination.maxChannelCount, 1);
 }
 
 /**

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -15,7 +15,6 @@ import { ProfileConditionValue } from '@jellyfin/sdk/lib/generated-client/models
 import { SubtitleDeliveryMethod } from '@jellyfin/sdk/lib/generated-client/models/subtitle-delivery-method';
 import { DeviceIds, getActiveDeviceId } from './castDevices';
 import {
-    hasSurroundSupport,
     hasTextTrackSupport,
     hasVP8Support,
     hasVP9Support,
@@ -30,7 +29,8 @@ import {
     getSupportedHLSVideoCodecs,
     getSupportedHLSAudioCodecs,
     getSupportedWebMAudioCodecs,
-    getSupportedAudioCodecs
+    getSupportedAudioCodecs,
+    getMaxAudioChannels
 } from './codecSupportHelper';
 
 interface ProfileOptions {
@@ -289,7 +289,7 @@ function getTranscodingProfiles(): TranscodingProfile[] {
     const TranscodingProfiles: TranscodingProfile[] = [];
 
     const hlsAudioCodecs = getSupportedHLSAudioCodecs();
-    const audioChannels: number = hasSurroundSupport() ? 6 : 2;
+    const audioChannels: number = getMaxAudioChannels();
 
     if (profileOptions.enableHls) {
         TranscodingProfiles.push({


### PR DESCRIPTION
Instead of relying on testing for support for AC-3 or E-AC-3, just directly ask for the number of audio channels.

This doesn't completely alleviate the issues of but is related to #87. At the very least, this is less aggressive about downmixing to 2 channels when the device supports it.