### PR TITLE
Set Vite's esbuild target to match build target

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
         target: 'es2015',
         assetsInlineLimit: 0
     },
+    esbuild: {
+        target: 'es2015'
+    },
     server: {
         port: 9000
     }


### PR DESCRIPTION
This is required for testing. By default esbuild target is esnext, which is not supported on old Cast clients that can be used for testing.