### PR TITLE
Load debug Shaka in non-prod builds

### DIFF
--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -892,6 +892,8 @@ if (!import.meta.env.PROD) {
     // quits once the client closes the connection.
     // options.maxInactivity = 3600;
 
+    options.shakaVariant = cast.framework.ShakaVariant.DEBUG;
+
     window.playerManager.addEventListener(
         cast.framework.events.category.CORE,
         (event: framework.events.Event) => {

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -881,7 +881,7 @@ controls.assignButton(
 
 const options = new cast.framework.CastReceiverOptions();
 
-// Global variable set by Webpack
+// Global variable set by Vite
 if (!import.meta.env.PROD) {
     window.castReceiverContext.setLoggerLevel(cast.framework.LoggerLevel.DEBUG);
     // Don't time out on me :(


### PR DESCRIPTION
https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.CastReceiverOptions#shakaVariant

From https://shaka-player-demo.appspot.com/docs/api/tutorial-debugging.html

> The compiled library has no usable stack traces and no logging. So to get more information, we need to switch to the debug library. The debug library is still compiled into a single bundle, but logging and other debug features are enabled.