### PR TITLE
Skip loading MPL player

### DIFF
--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -904,6 +904,7 @@ if (!import.meta.env.PROD) {
 }
 
 options.useShakaForHls = true;
+options.skipMplLoad = true;
 options.playbackConfig = new cast.framework.PlaybackConfig();
 // Set the player to start playback as soon as there are five seconds of
 // media content buffered. Default is 10.


### PR DESCRIPTION
This app has opted in to use the newer Shaka player for HLS, so there is no need to also load the MPL player which is no longer required.