### PR TITLE
Remove direct dependency on Axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
             "version": "3.0.0",
             "license": "GPL-2.0-or-later",
             "dependencies": {
-                "@jellyfin/sdk": "0.10.0",
-                "axios": "1.8.4"
+                "@jellyfin/sdk": "0.10.0"
             },
             "devDependencies": {
                 "@types/chromecast-caf-receiver": "6.0.21",
@@ -2180,7 +2179,8 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "peer": true
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
@@ -2203,6 +2203,7 @@
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
             "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -2422,6 +2423,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "peer": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -2649,6 +2651,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -3529,6 +3532,7 @@
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             },
@@ -3552,6 +3556,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
             "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "peer": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -4478,6 +4483,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4486,6 +4492,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "peer": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -4941,7 +4948,8 @@
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "peer": true
         },
         "node_modules/punycode": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
         "url": "https://github.com/jellyfin/jellyfin-chromecast/issues"
     },
     "dependencies": {
-        "@jellyfin/sdk": "0.10.0",
-        "axios": "1.8.4"
+        "@jellyfin/sdk": "0.10.0"
     },
     "devDependencies": {
         "@types/chromecast-caf-receiver": "6.0.21",

--- a/src/components/jellyfinApi.ts
+++ b/src/components/jellyfinApi.ts
@@ -1,27 +1,5 @@
 import { Api, Jellyfin } from '@jellyfin/sdk';
-import axios from 'axios';
 import { version as packageVersion } from '../../package.json';
-
-axios.interceptors.request.use((request) => {
-    console.log(`requesting url: ${request.url}`);
-
-    return request;
-});
-
-axios.interceptors.response.use(
-    (response) => {
-        console.log(
-            `response status: ${response.status}, url: ${response.request.responseURL}`
-        );
-
-        return response;
-    },
-    // eslint-disable-next-line promise/prefer-await-to-callbacks
-    (error) => {
-        console.log(`request failed to url: ${error.request.url}`);
-        throw error;
-    }
-);
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export abstract class JellyfinApi {


### PR DESCRIPTION
We no longer make our own requests, the TS SDK does all of that for us. Thus we don't need to have Axios as direct dependency or use the hooks from it anymore.