### PR TITLE
Fix profile resolution and H.264 & VP9 codec strings

### DIFF
--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -65,7 +65,9 @@ function getCodecString(
             //   * https://en.wikipedia.org/wiki/Advanced_Video_Coding#Levels
             level = level ?? 10;
 
-            return `avc1.${profileFlag}${level.toString(16)}`;
+            const levelFlag = level.toString(16).padStart(2, '0');
+
+            return `avc1.${profileFlag}${levelFlag}`;
         }
         case VideoCodec.H265: {
             let profileFlag: string;
@@ -123,7 +125,7 @@ function getCodecString(
 
             const bitDepthFlag = bitDepth.toString().padStart(2, '0');
 
-            return `vp9.${profileFlag}.${level}.${bitDepthFlag}`;
+            return `vp09.${profileFlag}.${level}.${bitDepthFlag}`;
         }
         case VideoCodec.AV1: {
             let profileFlag: string;
@@ -423,9 +425,9 @@ export function getVideoProfileSupport(codec: VideoCodec): string[] {
         }
     })();
 
+    const mimeType = videoCodecToMimeType(codec);
     const supportedProfiles = possibleProfiles.filter((profile) => {
         const codecString = getCodecString(codec, profile);
-        const mimeType = videoCodecToMimeType(codec);
 
         return castContext.canDisplayType(mimeType, codecString);
     });

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -369,31 +369,12 @@ function getTranscodingProfiles(): TranscodingProfile[] {
         return transcodingProfiles;
     }
 
-    // Create conditions that always need to be honored, regardless of the
-    // codecs profile.
-    //
-    // For now, it's the screen size. Since this is a transcoding profile,
-    // request that the video be no larger than the screen.
-    const profileConditions = [
-        createProfileCondition(
-            ProfileConditionValue.Width,
-            ProfileConditionType.LessThanEqual,
-            window.screen.width.toString()
-        ),
-        createProfileCondition(
-            ProfileConditionValue.Height,
-            ProfileConditionType.LessThanEqual,
-            window.screen.height.toString()
-        )
-    ];
-
     const hlsVideoCodecs = getSupportedHLSVideoCodecs();
 
     if (hlsVideoCodecs.length && hlsAudioCodecs.length) {
         transcodingProfiles.push({
             AudioCodec: hlsAudioCodecs.join(','),
             BreakOnNonKeyFrames: false,
-            Conditions: profileConditions,
             Container: 'mp4',
             Context: EncodingContext.Streaming,
             MaxAudioChannels: audioChannels.toString(),
@@ -410,7 +391,6 @@ function getTranscodingProfiles(): TranscodingProfile[] {
     if (webmAudioCodecs.length > 0 && hlsVideoCodecs.length > 0) {
         transcodingProfiles.push({
             AudioCodec: webmAudioCodecs.join(','),
-            Conditions: profileConditions,
             Container: 'webm',
             Context: EncodingContext.Streaming,
             // If audio transcoding is needed, limit channels to number of physical audio channels


### PR DESCRIPTION
This is a follow up on #744.

Fixes the following issues:

* `window.screen` does not always report the screen's resolution correctly, so it is unreliable and often limits the resolution unnecessarily.
* The VP9 codec string needs to be `vp09.*`
* The level flag for H.264 was not being padded correctly, causing the H.264 to be marked as unsupported.

Interestingly, I've discovered a lot of Android TVs with a hardware AV1 decoder don't report support correctly to the cast context, but there isn't much we can do 🤷.