### PR TITLE
Only send HLS `TranscodingProfile`s if they exist

### DIFF
--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -598,7 +598,7 @@ export function getSupportedMP4VideoCodecs(): VideoCodec[] {
  * @returns Supported MP4 audio codecs.
  */
 export function getSupportedMP4AudioCodecs(): string[] {
-    const codecs = [];
+    const codecs = ['aac', 'mp3', 'opus'];
 
     if (hasEAC3Support()) {
         codecs.push('eac3');
@@ -607,9 +607,6 @@ export function getSupportedMP4AudioCodecs(): string[] {
     if (hasAC3Support()) {
         codecs.push('ac3');
     }
-
-    codecs.push('aac');
-    codecs.push('mp3');
 
     return codecs;
 }

--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -404,6 +404,14 @@ function getTranscodingProfiles(): TranscodingProfile[] {
             Type: DlnaProfileType.Video,
             VideoCodec: hlsVideoCodecs.map((codec) => codec as string).join(',')
         });
+
+        // Currently, if there are any HLS codecs, stop early. This mimics the web client's
+        // behavior and works around a bug where the server may pick other single-codec containers
+        // because the audio codec needs less transcoding.
+        //
+        // In reality, we're only really losing out on the VPx codecs, which have middling compute
+        // to efficiency ratios anyways.
+        return transcodingProfiles;
     }
 
     const mp4VideoCodecs = getSupportedMP4VideoCodecs();


### PR DESCRIPTION
## Issue

This works around the following bug. One could argue that this is more of a server issue but this change makes the client mimic the web client behavior more closely.

Previously, we would send both HTTP and HLS transcoding profiles. Imagine a scenario where we need to do video transcoding but not audio transcoding. The server currently picks a profile where the audio doesn't need to be transcoded, which may not be an optimal video codec to transcode to.

Additionally, this adds `opus` to the list of supported mp4 audio codecs. Opus was added to the ISOBMFF standard 7 years ago -- see: https://www.opus-codec.org/docs/opus_in_isobmff.html

This was discussed at length with gnattu in Matrix.