### PR TITLE
Fix audio channel limits

### DIFF
--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -213,17 +213,6 @@ export function hasAC3Support(): boolean {
 }
 
 /**
- * Checks for the number of audio channels supported on the device.
- * @returns The maximum number of audio channels supported.
- */
-export function getMaxAudioChannels(): number {
-    const audioCtx = new window.AudioContext();
-
-    // Make sure we allow at least 1 channel, in case of some bad output.
-    return Math.max(audioCtx.destination.maxChannelCount, 1);
-}
-
-/**
  * Checks for every supported video codec.
  * @returns An array of supported video codecs
  */
@@ -639,9 +628,9 @@ export function getSupportedWebMAudioCodecs(): string[] {
 }
 
 /**
- * Get supported audio codecs suitable for use in a WebM container.
- * @returns All supported WebM audio codecs.
+ * Get supported audio codecs.
+ * @returns the supported audio codecs.
  */
 export function getSupportedAudioCodecs(): string[] {
-    return ['opus', 'mp3', 'aac', 'flac', 'webma', 'wav'];
+    return ['opus', 'vorbis', 'mp3', 'aac', 'flac', 'wav'];
 }


### PR DESCRIPTION
Currently, the Cast SDK does not accurately report the number of audio channels available on Cast-enabled Android TVs. Because many cast targets have some multi-channel support, do not place a limit on audio channels and let Chromium/the Cast SDK handle the audio downmixing if necessary. On some devices with potentially variable audio setups, like TVs, the Cast SDK is free to defer the downmixing to the device's audio stack.

However, the Cast SDK has limitations on which codecs support non-stereo, multi-channel audio. This change addresses these limitations much more precisely.

See: https://issuetracker.google.com/issues/69112577#comment20
See: https://issuetracker.google.com/issues/330548743

Fixes #66 
Fixes #764
Fixes #120