### PR TITLE
Fix detection of levels for misbehaving devices like Chromecast gen 2

### DIFF
--- a/src/components/codecSupportHelper.ts
+++ b/src/components/codecSupportHelper.ts
@@ -672,12 +672,19 @@ export function getVideoCodecHighestLevelSupport(
         }
     })();
 
-    const supportedLevels = possibleLevels.filter((level) => {
-        const mimeType = videoCodecToMimeType(codec);
-        const codecString = getCodecString(codec, profile, level, bitDepth);
+    const mimeType = videoCodecToMimeType(codec);
+    const supportedLevels: number[] = [];
 
-        return castContext.canDisplayType(mimeType, codecString);
-    });
+    for (const level of possibleLevels) {
+        const codecString = getCodecString(codec, profile, level, bitDepth);
+        const supported = castContext.canDisplayType(mimeType, codecString);
+
+        if (!supported) {
+            break;
+        }
+
+        supportedLevels.push(level);
+    }
 
     return supportedLevels.length > 0
         ? supportedLevels[supportedLevels.length - 1]


### PR DESCRIPTION
Chromecast gen 2 does not accurately report whether it can play higher H264 levels. Change the logic so that each level is checked until one is reported incompatible and stop checking higher levels after that point.

Fixes #873 