### PR TITLE
Disable verbatimModuleSyntax

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
         "allowJs": true,
         "sourceMap": true,
         "outDir": "./dist/",
-        "verbatimModuleSyntax": true,
         "strict": true,
         "baseUrl": "./src",
         "paths": {


### PR DESCRIPTION
Recent changes to @types/chromecast-caf-receiver means this flag cannot be used.

Unblocks #857