### PR TITLE
Remove unnecessary interface

### DIFF
--- a/src/components/deviceprofileBuilder.ts
+++ b/src/components/deviceprofileBuilder.ts
@@ -34,10 +34,6 @@ import {
     getVideoRangeSupport
 } from './codecSupportHelper';
 
-interface ProfileOptions {
-    bitrateSetting: number;
-}
-
 /**
  * Create and return a new ProfileCondition
  * @param Property - What property the condition should test.
@@ -528,18 +524,15 @@ function getSubtitleProfiles(): SubtitleProfile[] {
 
 /**
  * Creates a device profile containing supported codecs for the active Cast device.
- * @param options - Profile options
+ * @param maxBitrate - maximum bitrate to be used by the server when streaming data
  * @returns Device profile.
  */
-export function getDeviceProfile(options: ProfileOptions): DeviceProfile {
+export function getDeviceProfile(maxBitrate: number): DeviceProfile {
     // MaxStaticBitrate seems to be for offline sync only
     const profile: DeviceProfile = {
-        MaxStaticBitrate: options.bitrateSetting,
-        MaxStreamingBitrate: options.bitrateSetting,
-        MusicStreamingTranscodingBitrate: Math.min(
-            options.bitrateSetting,
-            192000
-        )
+        MaxStaticBitrate: maxBitrate,
+        MaxStreamingBitrate: maxBitrate,
+        MusicStreamingTranscodingBitrate: Math.min(maxBitrate, 192000)
     };
 
     profile.DirectPlayProfiles = getDirectPlayProfiles();

--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -263,10 +263,7 @@ window.playerManager.addEventListener(
  */
 export async function reportDeviceCapabilities(): Promise<void> {
     const maxBitrate = await getMaxBitrate();
-
-    const deviceProfile = getDeviceProfile({
-        bitrateSetting: maxBitrate
-    });
+    const deviceProfile = getDeviceProfile(maxBitrate);
 
     hasReportedCapabilities = true;
 

--- a/src/components/playbackManager.ts
+++ b/src/components/playbackManager.ts
@@ -206,9 +206,7 @@ export abstract class PlaybackManager {
         DocumentManager.setAppStatus(AppStatus.Loading);
 
         const maxBitrate = await getMaxBitrate();
-        const deviceProfile = getDeviceProfile({
-            bitrateSetting: maxBitrate
-        });
+        const deviceProfile = getDeviceProfile(maxBitrate);
         let playbackInfo: PlaybackInfoResponse = {};
 
         try {


### PR DESCRIPTION
The `ProfileOptions` interface only has one property and doesn't provide any value.