### PR TITLE
fix JellyfinApi.jellyfinApi undefined

### DIFF
--- a/src/components/maincontroller.ts
+++ b/src/components/maincontroller.ts
@@ -103,7 +103,10 @@ function onMediaElementVolumeChange(event: framework.system.Event): void {
     window.volume = (event as framework.system.SystemVolumeChangedEvent).data;
     console.log(`Received volume update: ${window.volume.level}`);
 
-    if (JellyfinApi.serverAddress !== null) {
+    if (
+        JellyfinApi.serverAddress !== null &&
+        JellyfinApi.jellyfinApi !== undefined
+    ) {
         reportEvent('volumechange', true);
     }
 }


### PR DESCRIPTION
I sometimes experienced weirdnesses on the casting Jellyfin side (like, the android app not connecting or other not identifiable bugs). So I did the only sane thing and built this chromecast receiver from source, containerized, and instrumented it with crash reporting using Sentry.
Not sure I pin pointed yet why the crashes/weirdness I saw happened, but at some point during normal usage I got a javascript crash on using an undefined value, so this patch is guarding against that case which happens, I don't really know why and don't remember (this was a few months ago and I didn't think to send that PR at the time)
Builds with node v22.16.0, npm run lint & npm run test OK